### PR TITLE
Read roo tracker

### DIFF
--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -54,9 +54,9 @@ all: rootcint lib bin shared libWCSim.a
 
 ROOTSO    := libWCSimRoot.so
 
-ROOTSRC  := ./src/WCSimRootEvent.cc ./include/WCSimRootEvent.hh ./src/WCSimRootGeom.cc ./include/WCSimRootGeom.hh ./include/WCSimPmtInfo.hh ./include/WCSimRootLinkDef.hh
+ROOTSRC  := ./src/WCSimRootEvent.cc ./include/WCSimRootEvent.hh ./src/WCSimRootGeom.cc ./include/WCSimRootGeom.hh ./include/WCSimPmtInfo.hh ./src/TJNuBeamFlux.cc ./include/TJNuBeamFlux.hh ./src/TNRooTrackerVtx.cc ./include/TNRooTrackerVtx.hh ./include/WCSimRootLinkDef.hh
 
-ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootDict.o 
+ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TNRooTrackerVtx.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TJNuBeamFlux.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootDict.o 
 
 shared: $(ROOTSRC) $(ROOTOBJS) 
 	g++ -shared -O $(ROOTOBJS) -o $(ROOTSO) $(ROOTLIBS)
@@ -66,7 +66,7 @@ libWCSim.a : $(ROOTOBJS)
 	ar clq $@ $(ROOTOBJS) 
 
 ./src/WCSimRootDict.cc : $(ROOTSRC)
-	rootcint  -f ./src/WCSimRootDict.cc -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh WCSimRootLinkDef.hh
+	rootcint  -f ./src/WCSimRootDict.cc -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh TJNuBeamFlux.hh TNRooTrackerVtx.hh WCSimRootLinkDef.hh
 
 rootcint: ./src/WCSimRootDict.cc
 

--- a/include/TJNuBeamFlux.hh
+++ b/include/TJNuBeamFlux.hh
@@ -1,0 +1,107 @@
+#ifndef JNuBeamFlux_hh_seen
+#define JNuBeamFlux_hh_seen
+
+#include <iostream>
+
+#include "TObject.h"
+#include "TObjString.h"
+
+///
+/// JNuBeam flux pass-through info. Both GRooTracker and NRooTracker inherit
+/// from this so as to avoid duplication of code. Currently up to date with 
+/// 11a version of pass-through info.
+///
+
+const int kNgmax = 12; 
+
+// This is the base class for all RooTracker type objects. For now
+// it is  empty and just so that an pass round pointers to
+// all derived classes (will be usefull for reweighting applications etc...)
+class RooTrackerVtxBase : public TObject {
+    public:
+        RooTrackerVtxBase();
+        virtual ~RooTrackerVtxBase(){}
+        ClassDef(RooTrackerVtxBase, 1);
+};
+
+class JNuBeamFlux : public RooTrackerVtxBase {
+
+    public:
+        JNuBeamFlux();
+        virtual ~JNuBeamFlux();
+
+        void Reset   (void);
+        // Using methods from TObject to remove 'hidden' compiler warnings
+        using TObject::Copy;
+        void Copy    (const JNuBeamFlux * flux);
+
+        //
+        // Meta information
+        //
+        long        NuFluxEntry;        ///< corresponding entry in orig flux file
+        TObjString* NuFileName;         ///< orig flux file name
+        //
+        // neutrino parent info
+        //
+        int         NuParentPdg;        ///< parent hadron pdg code
+        int         NuParentDecMode;    ///< parent hadron decay mode
+        double      NuParentDecP4 [4];  ///< parent hadron 4-momentum at decay
+        double      NuParentDecX4 [4];  ///< parent hadron 4-position at decay 
+        float       NuCospibm;          ///< parent hadron cos(theta) relative to beam at decay
+        float       NuNorm;             ///< Normalization weight 
+        double      NuParentProP4 [4];  ///< parent hadron 4-momentum at production 
+        double      NuParentProX4 [4];  ///< parent hadron 4-position at production  
+        float       NuCospi0bm;         ///< parent hadron cos(theta) relative to beam at production
+        float       NuRnu;              ///< neutrino r position at ND5/6 plane 
+        float       NuXnu [2];          ///< neutrino (x,y) position at ND5/6 plane 
+        int         NuIdfd;             ///< Detector ID
+        //
+        // primary particle information
+        // 
+        int         NuGipart;           ///< primary particle ID  
+        float       NuGpos0[3];         ///< primary particle starting point 
+        float       NuGvec0[3];         ///< primary particle direction at starting point 
+        float       NuGamom0;           ///< momentum of the primary particle at the starting point 
+        //
+        // Interation History Information
+        //
+        int         NuNg;               ///< Number of interaction steps 
+        float       NuGp[kNgmax][3];    ///< Momentum of ancestor particle 
+        float       NuGcosbm[kNgmax];   ///< Ancestor particle cos(theta) relative to beam
+        float       NuGv[kNgmax][3];    ///< Position of ancestor particle 
+        int         NuGpid[kNgmax];     ///< PDG ancestor particle ID 
+        int         NuGmec[kNgmax];     ///< particle production mechanism of ancestor particle
+        //
+        // Normalization and Transfer Matrix Information
+        //
+        float       NuEnusk;            ///< Neutrino Energy at SK 
+        float       NuNormsk;           ///< Normalization weight at SK 
+        float       NuAnorm;            ///< ND Acceptance Weight 
+        //
+        // Out-of-target Secondary Interactions
+        //
+        int         NuGmat[kNgmax];     ///< material in which the particle originates
+        float       NuGdistc[kNgmax];   ///< distance traveled through carbon
+        float       NuGdistal[kNgmax];  ///< distance traveled through aluminum
+        float       NuGdistti[kNgmax];  ///< distance traveled through titanium
+        float       NuGdistfe[kNgmax];  ///< distance traveled through iron
+        //                                  
+        // Beam parameter information 
+        //                                     
+        float       NuVersion;          ///< jnubeam flux version 
+        int         NuTuneid;           ///< beam tune ID # 
+        int         NuNtrig;            ///< Number of triggers
+        int         NuPint;             ///< Interaction model ID 
+        float       NuBpos[2];          ///< Beam center position 
+        float       NuBtilt[2];         ///< Beam angle  
+        float       NuBrms[2];          ///< Beam RMS width 
+        float       NuEmit[2];          ///< Beam Emittance 
+        float       NuAlpha[2];         ///< Beam Alpha 
+        float       NuHcur[3];          ///< Horn currents 
+        int         NuRand;             ///< Random seed
+        //    int         NuRseed[2];         // Random seed
+
+        ClassDef(JNuBeamFlux, 1);
+};
+
+#endif

--- a/include/TNRooTrackerVtx.hh
+++ b/include/TNRooTrackerVtx.hh
@@ -1,0 +1,195 @@
+//
+//
+#ifndef NRooTrackerVtx_hh_seen
+#define NRooTrackerVtx_hh_seen
+
+#include <iostream>
+#include <vector>
+
+#include "TObject.h"
+#include "TBits.h"
+#include "TObjString.h"
+
+#include "TJNuBeamFlux.hh"
+
+using std::ostream;
+
+///
+/// This is a simple event class which is essentially an objectified version
+/// of the NEUT nRooTracker output format. Because the nRooTracker is forcing 
+/// NEUT event into a GENIE defined storage care needs to be taken when
+/// interpreting the meaning of various data members. For example the StdHepStatus
+/// does not have a one to one mapping to GENIE StdHep status. Using this class 
+/// with GENIE based utils or the GENIE ReWeighting tools can (and most likely
+/// will result in false results!
+///
+/// Therefore, the native NEUT particle information common blocks (VCWORK, FSIHIST)
+/// are included. Analysis tools under development...
+
+/// DBrailsford 10-2013: All 1D arrays are now in a dynamic format (rather than fixed length). 
+/// Due to the class structure of the oaAnalysis NRooTracker object being used to extract the 
+/// information from the numc file, two versions of the 1D arrays are initialised.  
+/// Each array has a dynamic version, and a 'Temp' fixed length version.  The 'Temp' version 
+/// extracts the info from the numc object and feeds the information in the dynamic version.
+/// The 'Temp' version of each data member is NOT saved to the rooTracker tree, only the dynamic version is.
+/// Note that for each new event, only the 'Temp' version of the data member is reset to a default value.
+/// This current implementation reduces the NRooTracker tree by ~10Mb.
+
+const int kNStdHepNPmax = 100;
+const int kNStdHepIdxPx = 0;
+const int kNStdHepIdxPy = 1;
+const int kNStdHepIdxPz = 2;
+const int kNStdHepIdxE  = 3;
+const int kNStdHepIdxX  = 0;
+const int kNStdHepIdxY  = 1;
+const int kNStdHepIdxZ  = 2;
+const int kNStdHepIdxT  = 3;
+
+const int kNEmaxvc = 100;
+const int kNEmaxvert = 100;
+const int kNEmaxvertp = 300;
+
+class NRooTrackerVtx : public JNuBeamFlux {
+
+    public:
+        NRooTrackerVtx();
+        ~NRooTrackerVtx();
+
+        void Reset   (void);
+        void Init    (void);
+
+        // Using methods from TObject to remove 'hidden' compiler warnings
+        using TObject::Copy;
+        using TObject::Print;
+
+        void Copy    (const NRooTrackerVtx * event);
+        void Print (const Option_t* = "") const;
+
+        // Define the output rootracker tree branches
+        TObjString* EvtCode;                         ///< generator-specific string with 'event code'
+        int         EvtNum;                          ///< event num.
+        double      EvtXSec;                         ///< cross section for selected event (1E-38 cm2) CORRECT
+        double      EvtDXSec;                        ///< cross section for selected event kinematics (1E-38 cm2 /{K^n}) CORRECT
+        double      EvtWght;                         ///< weight for that event CORRECT
+        double      EvtProb;                         ///< probability for that event (given cross section, path lengths, etc) CORRECT
+        double      EvtVtx[4];                       ///< event vertex position in detector coord syst (SI) CORRECT
+        int         StdHepN;                         ///< number of particles in particle array 
+        //
+        //  stdhep-like particle array
+        //
+        int*        StdHepPdg; //[StdHepN] ///< pdg codes (& generator specific codes for pseudoparticles)
+        int         StdHepPdgTemp   [kNStdHepNPmax];     //!
+
+        int*        StdHepStatus; //[StdHepN] ///< generator-specific status code 
+        int         StdHepStatusTemp[kNStdHepNPmax];     //!
+
+        double      StdHepX4    [kNStdHepNPmax][4];  ///< 4-x (x, y, z, t) of particle in hit nucleus frame (fm) CORRECT
+
+        double      StdHepP4    [kNStdHepNPmax][4];  ///< 4-p (px,py,pz,E) of particle in LAB frame (GeV) CORRECT
+
+        double      StdHepPolz  [kNStdHepNPmax][3];  ///< polarization vector CORRECT
+
+        int  StdHepFdTemp    [kNStdHepNPmax];     //!
+        int  StdHepLdTemp    [kNStdHepNPmax];     //!
+        int  StdHepFmTemp    [kNStdHepNPmax];     //!
+        int  StdHepLmTemp    [kNStdHepNPmax];     //!
+        int*  StdHepFd;    //[StdHepN] ///< first daughter
+        int*  StdHepLd;    //[StdHepN] ///< last daughter
+        int*  StdHepFm;    //[StdHepN] ///< first mother 
+        int*  StdHepLm;    //[StdHepN] ///< last mother
+
+        // NEUT native VCWORK information
+        int    NEnvc;                         ///< Number of particles 
+
+        int    NEipvcTemp[kNEmaxvc];          //! PDG particle code
+        int*   NEipvc; //[NEnvc]              ///< PDG particle code
+
+        float  NEpvc[kNEmaxvc][3];            ///< 3-momentum (MeV/c) CORRECT
+
+        int    NEiorgvcTemp[kNEmaxvc];        //!
+        int*   NEiorgvc; //[NEnvc]            ///<  Index of parent (Fortran convention: starting at 1)
+
+
+        /// Flag of final state:   
+        ///     0 : DETERMINED LATER PROCEDURE
+        ///     1 : DECAY TO OTHER PARTICLE
+        ///     2 : ESCAPE FROM DETECTOR
+        ///     3 : ABSORPTION
+        ///     4 : CHARGE EXCHANGE
+        ///     5 : STOP A NOT CONSIDER IN M.C. 
+        ///     6 : E.M. SHOWER
+        ///     7 : HADRON PRODUCTION
+        ///     8 : QUASI-ELASTIC SCATTER
+        ///     9 : FORWARD (ELASTIC-LIKE) SCATTER
+
+        int    NEiflgvcTemp[kNEmaxvc];          //! 
+        int    NEicrnvcTemp[kNEmaxvc];          //!
+        int*    NEiflgvc; //[NEnvc]             ///< Flag of final state         
+        int*    NEicrnvc; //[NEnvc]             ///< Escaped nucleus (1) or not (0)
+
+
+        // Rest of the NEUT variables below are mainly for internal reweighting routines 
+
+        float NEcrsx;    	///< Cross section calculation variables (currently used for coherent interactions) CORRECT
+
+        float NEcrsy;    	///< Cross section calculation variables (currently used for coherent interactions) CORRECT
+
+        float NEcrsz;    	///< Cross section calculation variables (currently used for coherent interactions) CORRECT
+
+        float NEcrsphi;    	///< Cross section calculation variables (currently used for coherent interactions) CORRECT
+
+
+        // NEUT FSIHIST pion interaction history 
+        int    NEnvert;                     ///< Number of vertices (including production and exit points)
+        float  NEposvert[kNEmaxvert][3];    ///< Position of vertex within nucleus (fm) CORRECT
+
+        ///< Interaction type 
+        ///< (*10 FOR HI-NRG interaction, >~400 MeV/c)
+        ///<     -1 : ESCAPE
+        ///<     0 : INITIAL (or unmatched parent vertex if I>1)
+        ///<     3 : ABSORPTION
+        ///<     4 : CHARGE EXCHANGE
+        ///<     7 : HADRON PRODUCTION (hi-nrg only, i.e. 70)
+        ///<     8 : QUASI-ELASTIC SCATTER
+        ///<     9 : FORWARD (ELASTIC-LIKE) SCATTER 
+
+        int    NEiflgvertTemp[kNEmaxvert];      //!
+        int*   NEiflgvert; //[NEnvert]          ///< Interaction type
+
+
+
+        int    NEnvcvert;                   ///< Number of intermediate particles (including initial and final)
+        float  NEdirvert[kNEmaxvertp][3];   ///< Direction of particle CORRECT
+
+        float  NEabspvertTemp[kNEmaxvertp];     //! 
+        float  NEabstpvertTemp[kNEmaxvertp];    //! 
+        int    NEipvertTemp[kNEmaxvertp];       //! 
+        int    NEivertiTemp[kNEmaxvertp];       //! 
+        int    NEivertfTemp[kNEmaxvertp];       //! 
+
+        float*  NEabspvert;  //[NEnvcvert]   ///<  Absolute momentum in the lab frame (MeV/c) CORRECT
+        float*  NEabstpvert; //[NEnvcvert]   ///<  Absolute momentum in the nucleon rest frame (MeV/c) CORRECT
+        int*    NEipvert;    //[NEnvcvert]   ///<  PDG particle code
+        int*    NEiverti;    //[NEnvcvert]   ///<  Index of initial vertex (pointing to nvert array above)
+        int*    NEivertf;    //[NEnvcvert]   ///<  Index of final vertex (pointing to nvert array above)
+
+        //
+        // etc 
+        //
+        TObjString* GeomPath;                        //
+
+        // Some pass through info
+        TObjString* GeneratorName;                   //
+        TObjString* OrigFileName;                   //
+        TObjString* OrigTreeName;                   //
+        int OrigEvtNum;
+        int OrigTreeEntries;
+        double OrigTreePOT;
+        double TimeInSpill;
+
+        int TruthVertexID;
+
+        ClassDef(NRooTrackerVtx, 1);
+};
+
+#endif

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -123,6 +123,9 @@ public:
 
   std::vector<WCSimPmtInfo*>* Get_Pmts() {return &fpmts;}
 
+  G4double GetWCIDDiameter(){ return WCIDDiameter; }
+  G4double GetWCIDHeight(){ return WCIDHeight; }
+
 private:
 
   // Tuning parameters

--- a/include/WCSimPrimaryGeneratorAction.hh
+++ b/include/WCSimPrimaryGeneratorAction.hh
@@ -27,8 +27,8 @@ class WCSimPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
     public:
         void GeneratePrimaries(G4Event* anEvent);
         void SetupBranchAddresses(NRooTrackerVtx* nrootrackervtx);
-        void OpenNeutFile(G4String fileName);
-        void CopyNeutVertex(NRooTrackerVtx* nrootrackervtx);
+        void OpenRootrackerFile(G4String fileName);
+        void CopyRootrackerVertex(NRooTrackerVtx* nrootrackervtx);
 
         // Normal gun setting calls these functions to fill jhfNtuple and Root tree
         void SetVtx(G4ThreeVector i)     { vtx = i; };
@@ -67,7 +67,7 @@ class WCSimPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
 
         // Variables set by the messenger
         G4bool   useMulineEvt;
-        G4bool   useNeutEvt;
+        G4bool   useRootrackerEvt;
         G4bool   useNormalEvt;
         G4bool   useLaserEvt;  //T. Akiri: Laser flag
         std::fstream inputFile;
@@ -92,23 +92,23 @@ class WCSimPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
         G4int    _counterRock; 
         G4int    _counterCublic;
 
-        // Counters to read NEUT event file
+        // Counters to read Rootracker event file
         int fEvNum;
         int fNEntries;
-        TFile* fInputNeutFile;
+        TFile* fInputRootrackerFile;
 
-        // Pointers to NEUT Rootracker vertex objects
+        // Pointers to Rootracker vertex objects
         // Temporary vertex that is saved if desired, according to WCSimIO macro option
         TTree* fRooTrackerTree;
-        NRooTrackerVtx* fTmpNeutVtx;
+        NRooTrackerVtx* fTmpRootrackerVtx;
 
     public:
 
         inline void SetMulineEvtGenerator(G4bool choice) { useMulineEvt = choice; }
         inline G4bool IsUsingMulineEvtGenerator() { return useMulineEvt; }
 
-        inline void SetNeutEvtGenerator(G4bool choice) { useNeutEvt = choice; }
-        inline G4bool IsUsingNeutEvtGenerator() { return useNeutEvt; }
+        inline void SetRootrackerEvtGenerator(G4bool choice) { useRootrackerEvt = choice; }
+        inline G4bool IsUsingRootrackerEvtGenerator() { return useRootrackerEvt; }
 
         inline void SetNormalEvtGenerator(G4bool choice) { useNormalEvt = choice; }
         inline G4bool IsUsingNormalEvtGenerator()  { return useNormalEvt; }

--- a/include/WCSimPrimaryGeneratorAction.hh
+++ b/include/WCSimPrimaryGeneratorAction.hh
@@ -28,7 +28,7 @@ class WCSimPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
         void GeneratePrimaries(G4Event* anEvent);
         void SetupBranchAddresses(NRooTrackerVtx* nrootrackervtx);
         void OpenNeutFile(G4String fileName);
-        void InitialiseNeutObjects();
+        void CopyNeutVertex(NRooTrackerVtx* nrootrackervtx);
 
         // Normal gun setting calls these functions to fill jhfNtuple and Root tree
         void SetVtx(G4ThreeVector i)     { vtx = i; };
@@ -97,13 +97,10 @@ class WCSimPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
         int fNEntries;
         TFile* fInputNeutFile;
 
-        // Pointers to NEUT Rootracker vertex objects and output tree
-        TClonesArray* fVertices;
-        TTree* fRooTrackerOutputTree;
+        // Pointers to NEUT Rootracker vertex objects
+        // Temporary vertex that is saved if desired, according to WCSimIO macro option
         TTree* fRooTrackerTree;
-        int fNVtx;
-        NRooTrackerVtx* fCurrNeutVtx;
-        NRooTrackerVtx* tempVtx;
+        NRooTrackerVtx* fTmpNeutVtx;
 
     public:
 
@@ -130,7 +127,6 @@ class WCSimPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
         }
         inline G4bool IsGeneratingVertexInRock() { return GenerateVertexInRock; }
         inline void SetGenerateVertexInRock(G4bool choice) { GenerateVertexInRock = choice; }
-        inline TTree* GetRooTrackerOutputTree() { return fRooTrackerOutputTree; }
 
 };
 

--- a/include/WCSimPrimaryGeneratorAction.hh
+++ b/include/WCSimPrimaryGeneratorAction.hh
@@ -7,6 +7,11 @@
 
 #include <fstream>
 
+#include "TFile.h"
+#include "TTree.h"
+#include "TNRooTrackerVtx.hh"
+#include "TClonesArray.h"
+
 class WCSimDetectorConstruction;
 class G4ParticleGun;
 class G4GeneralParticleSource;
@@ -15,95 +20,117 @@ class WCSimPrimaryGeneratorMessenger;
 
 class WCSimPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
 {
-public:
-  WCSimPrimaryGeneratorAction(WCSimDetectorConstruction*);
-  ~WCSimPrimaryGeneratorAction();
-  
-public:
-  void GeneratePrimaries(G4Event* anEvent);
+    public:
+        WCSimPrimaryGeneratorAction(WCSimDetectorConstruction*);
+        ~WCSimPrimaryGeneratorAction();
 
-  // Normal gun setting calls these functions to fill jhfNtuple and Root tree
-  void SetVtx(G4ThreeVector i)     { vtx = i; };
-  void SetBeamEnergy(G4double i)   { beamenergy = i; };
-  void SetBeamDir(G4ThreeVector i) { beamdir = i; };
-  void SetBeamPDG(G4int i)         { beampdg = i; };
+    public:
+        void GeneratePrimaries(G4Event* anEvent);
+        void SetupBranchAddresses(NRooTrackerVtx* nrootrackervtx);
+        void OpenNeutFile(G4String fileName);
+        void InitialiseNeutObjects();
 
-  // These go with jhfNtuple
-  G4int GetVecRecNumber(){return vecRecNumber;}
-  G4int GetMode() {return mode;};
-  G4int GetVtxVol() {return vtxvol;};
-  G4ThreeVector GetVtx() {return vtx;}
-  G4int GetNpar() {return npar;};
-  G4int GetBeamPDG() {return beampdg;};
-  G4double GetBeamEnergy() {return beamenergy;};
-  G4ThreeVector GetBeamDir() {return beamdir;};
-  G4int GetTargetPDG() {return targetpdg;};
-  G4double GetTargetEnergy() {return targetenergy;};
-  G4ThreeVector GetTargetDir() {return targetdir;};
+        // Normal gun setting calls these functions to fill jhfNtuple and Root tree
+        void SetVtx(G4ThreeVector i)     { vtx = i; };
+        void SetBeamEnergy(G4double i)   { beamenergy = i; };
+        void SetBeamDir(G4ThreeVector i) { beamdir = i; };
+        void SetBeamPDG(G4int i)         { beampdg = i; };
 
-  // older ...
-  G4double GetNuEnergy() {return nuEnergy;};
-  G4double GetEnergy() {return energy;};
-  G4double GetXPos() {return xPos;};
-  G4double GetYPos() {return yPos;};
-  G4double GetZPos() {return zPos;};
-  G4double GetXDir() {return xDir;};
-  G4double GetYDir() {return yDir;};
-  G4double GetZDir() {return zDir;};
+        // These go with jhfNtuple
+        G4int GetVecRecNumber(){return vecRecNumber;}
+        G4int GetMode() {return mode;};
+        G4int GetVtxVol() {return vtxvol;};
+        G4ThreeVector GetVtx() {return vtx;}
+        G4int GetNpar() {return npar;};
+        G4int GetBeamPDG() {return beampdg;};
+        G4double GetBeamEnergy() {return beamenergy;};
+        G4ThreeVector GetBeamDir() {return beamdir;};
+        G4int GetTargetPDG() {return targetpdg;};
+        G4double GetTargetEnergy() {return targetenergy;};
+        G4ThreeVector GetTargetDir() {return targetdir;};
 
-private:
-  WCSimDetectorConstruction*      myDetector;
-  G4ParticleGun*                  particleGun;
-  G4GeneralParticleSource*        MyGPS;  //T. Akiri: GPS to run Laser
-  WCSimPrimaryGeneratorMessenger* messenger;
+        // older ...
+        G4double GetNuEnergy() {return nuEnergy;};
+        G4double GetEnergy() {return energy;};
+        G4double GetXPos() {return xPos;};
+        G4double GetYPos() {return yPos;};
+        G4double GetZPos() {return zPos;};
+        G4double GetXDir() {return xDir;};
+        G4double GetYDir() {return yDir;};
+        G4double GetZDir() {return zDir;};
 
-  // Variables set by the messenger
-  G4bool   useMulineEvt;
-  G4bool   useNormalEvt;
-  G4bool   useLaserEvt;  //T. Akiri: Laser flag
-  std::fstream inputFile;
-  G4String vectorFileName;
-  G4bool   GenerateVertexInRock;
+    private:
+        WCSimDetectorConstruction*      myDetector;
+        G4ParticleGun*                  particleGun;
+        G4GeneralParticleSource*        MyGPS;  //T. Akiri: GPS to run Laser
+        WCSimPrimaryGeneratorMessenger* messenger;
 
-  // These go with jhfNtuple
-  G4int mode;
-  G4int vtxvol;
-  G4ThreeVector vtx;
-  G4int npar;
-  G4int beampdg, targetpdg;
-  G4ThreeVector beamdir, targetdir;
-  G4double beamenergy, targetenergy;
-  G4int vecRecNumber;
+        // Variables set by the messenger
+        G4bool   useMulineEvt;
+        G4bool   useNeutEvt;
+        G4bool   useNormalEvt;
+        G4bool   useLaserEvt;  //T. Akiri: Laser flag
+        std::fstream inputFile;
+        G4String vectorFileName;
+        G4bool   GenerateVertexInRock;
 
-  G4double nuEnergy;
-  G4double energy;
-  G4double xPos, yPos, zPos;
-  G4double xDir, yDir, zDir;
+        // These go with jhfNtuple
+        G4int mode;
+        G4int vtxvol;
+        G4ThreeVector vtx;
+        G4int npar;
+        G4int beampdg, targetpdg;
+        G4ThreeVector beamdir, targetdir;
+        G4double beamenergy, targetenergy;
+        G4int vecRecNumber;
 
-  G4int    _counterRock; 
-  G4int    _counterCublic; 
-public:
+        G4double nuEnergy;
+        G4double energy;
+        G4double xPos, yPos, zPos;
+        G4double xDir, yDir, zDir;
 
-  inline void SetMulineEvtGenerator(G4bool choice) { useMulineEvt = choice; }
-  inline G4bool IsUsingMulineEvtGenerator() { return useMulineEvt; }
+        G4int    _counterRock; 
+        G4int    _counterCublic;
 
-  inline void SetNormalEvtGenerator(G4bool choice) { useNormalEvt = choice; }
-  inline G4bool IsUsingNormalEvtGenerator()  { return useNormalEvt; }
+        // Counters to read NEUT event file
+        int fEvNum;
+        int fNEntries;
+        TFile* fInputNeutFile;
 
-  //T. Akiri: Addition of function for the laser flag
-  inline void SetLaserEvtGenerator(G4bool choice) { useLaserEvt = choice; }
-  inline G4bool IsUsingLaserEvtGenerator()  { return useLaserEvt; }
+        // Pointers to NEUT Rootracker vertex objects and output tree
+        TClonesArray* fVertices;
+        TTree* fRooTrackerOutputTree;
+        TTree* fRooTrackerTree;
+        int fNVtx;
+        NRooTrackerVtx* fCurrNeutVtx;
+        NRooTrackerVtx* tempVtx;
 
-  inline void OpenVectorFile(G4String fileName) 
-  {
-    if ( inputFile.is_open() ) 
-      inputFile.close();
+    public:
 
-    vectorFileName = fileName;
-    inputFile.open(vectorFileName, std::fstream::in);
-  }
-  inline G4bool IsGeneratingVertexInRock() { return GenerateVertexInRock; }
-  inline void SetGenerateVertexInRock(G4bool choice) { GenerateVertexInRock = choice; }
+        inline void SetMulineEvtGenerator(G4bool choice) { useMulineEvt = choice; }
+        inline G4bool IsUsingMulineEvtGenerator() { return useMulineEvt; }
+
+        inline void SetNeutEvtGenerator(G4bool choice) { useNeutEvt = choice; }
+        inline G4bool IsUsingNeutEvtGenerator() { return useNeutEvt; }
+
+        inline void SetNormalEvtGenerator(G4bool choice) { useNormalEvt = choice; }
+        inline G4bool IsUsingNormalEvtGenerator()  { return useNormalEvt; }
+
+        //T. Akiri: Addition of function for the laser flag
+        inline void SetLaserEvtGenerator(G4bool choice) { useLaserEvt = choice; }
+        inline G4bool IsUsingLaserEvtGenerator()  { return useLaserEvt; }
+
+        inline void OpenVectorFile(G4String fileName) 
+        {
+            if ( inputFile.is_open() ) 
+                inputFile.close();
+
+            vectorFileName = fileName;
+            inputFile.open(vectorFileName, std::fstream::in);
+        }
+        inline G4bool IsGeneratingVertexInRock() { return GenerateVertexInRock; }
+        inline void SetGenerateVertexInRock(G4bool choice) { GenerateVertexInRock = choice; }
+        inline TTree* GetRooTrackerOutputTree() { return fRooTrackerOutputTree; }
 
 };
 

--- a/include/WCSimPrimaryGeneratorMessenger.hh
+++ b/include/WCSimPrimaryGeneratorMessenger.hh
@@ -20,6 +20,9 @@ class WCSimPrimaryGeneratorMessenger: public G4UImessenger
   
  private:
   WCSimPrimaryGeneratorAction* myAction;
+  // Boolean to determine whether the neutrino generator has been set yet
+  // Need to know whether we expect to open a ROOT file or a text file
+  bool genSet;
   
  private: //commands
   G4UIdirectory*      mydetDirectory;

--- a/include/WCSimRootLinkDef.hh
+++ b/include/WCSimRootLinkDef.hh
@@ -15,5 +15,8 @@
 #pragma link C++ class WCSimRootGeom+;
 #pragma link C++ class WCSimRootPMT+;
 #pragma link C++ class WCSimPmtInfo+;
+#pragma link C++ class RooTrackerVtxBase+;
+#pragma link C++ class JNuBeamFlux+;
+#pragma link C++ class NRooTrackerVtx+;
 
 #endif

--- a/include/WCSimRunAction.hh
+++ b/include/WCSimRunAction.hh
@@ -49,9 +49,9 @@ public:
   void incrementCatcherHits()     { numberOfTimesCatcherHit++;}
   void SetNtuples(int ntup) {ntuples=ntup;}
 
-  NRooTrackerVtx* GetNeutVertex();
-  void FillNeutVertexTree() { fRooTrackerOutputTree->Fill();}
-  void ClearNeutVertexArray() { 
+  NRooTrackerVtx* GetRootrackerVertex();
+  void FillRootrackerVertexTree() { fRooTrackerOutputTree->Fill();}
+  void ClearRootrackerVertexArray() { 
       fVertices->Clear(); 
       fNVtx = 0;
   }

--- a/include/WCSimRunAction.hh
+++ b/include/WCSimRunAction.hh
@@ -7,9 +7,12 @@
 
 #include "TFile.h"
 #include "TTree.h"
+#include "TClonesArray.h"
 #include "WCSimRootEvent.hh"
 #include "WCSimRootGeom.hh"
 #include "WCSimDetectorConstruction.hh"
+
+#include "TNRooTrackerVtx.hh"
 
 class G4Run;
 class WCSimRunActionMessenger;
@@ -24,7 +27,9 @@ public:
   void BeginOfRunAction(const G4Run*);
   void EndOfRunAction(const G4Run*);
   void SetRootFileName(G4String fname) { RootFileName = fname; }
+  void SetSaveRooTracker(G4bool fsave) { SaveRooTracker = fsave; }
   G4String GetRootFileName() { return RootFileName; }
+  bool GetSaveRooTracker() { return SaveRooTracker; }
   void FillGeoTree();
   TTree* GetTree(){return WCSimTree;}
   TTree* GetGeoTree(){return geoTree;}
@@ -44,6 +49,13 @@ public:
   void incrementCatcherHits()     { numberOfTimesCatcherHit++;}
   void SetNtuples(int ntup) {ntuples=ntup;}
 
+  NRooTrackerVtx* GetNeutVertex();
+  void FillNeutVertexTree() { fRooTrackerOutputTree->Fill();}
+  void ClearNeutVertexArray() { 
+      fVertices->Clear(); 
+      fNVtx = 0;
+  }
+
 private:
   // MFechner : set by the messenger
   std::string RootFileName;
@@ -58,6 +70,11 @@ private:
   int numberOfTimesWaterTubeHit;
   int numberOfTimesFVWaterTubeHit;
   int numberOfTimesCatcherHit;
+
+  TClonesArray* fVertices;
+  TTree* fRooTrackerOutputTree;
+  int fNVtx;
+  bool SaveRooTracker;
 
   WCSimRunActionMessenger* messenger;
   int ntuples;  // 1 for ntuples to be written

--- a/include/WCSimRunActionMessenger.hh
+++ b/include/WCSimRunActionMessenger.hh
@@ -4,6 +4,7 @@
 class WCSimRunAction;
 class G4UIdirectory;
 class G4UIcmdWithAString;
+class G4UIcmdWithABool;
 
 #include "G4UImessenger.hh"
 #include "globals.hh"
@@ -23,6 +24,8 @@ class WCSimRunActionMessenger: public G4UImessenger
  private: //commands
   G4UIdirectory*      WCSimIODir;
   G4UIcmdWithAString* RootFile;
+  G4UIcmdWithABool* RooTracker;
+
 };
 
 #endif

--- a/novis.mac
+++ b/novis.mac
@@ -57,7 +57,10 @@
 
 ## select the input nuance-formatted vector file
 ## you can of course use your own
-#/mygen/vecfile inputvectorfile
+# Or you can use the G4 Particle Gun below
+# Or a NEUT vector file
+/mygen/generator normal
+#/mygen/vecfile genev_320a_1km_nd2_9xx_test.root
 #/mygen/vecfile h2o.2km.001-009x3_G4.kin
 #/mygen/vecfile mu+.out
 
@@ -73,8 +76,6 @@
 /DarkRate/SetConvert 1.367
 #/DarkRate/SetConvert 1.120 #For HPDs
 
-# Or you can use the G4 Particle Gun
-/mygen/generator normal
 /gun/particle e-
 #/gun/particle pi0
 /gun/energy 500 MeV
@@ -82,8 +83,11 @@
 /gun/position 0 0 0  
 
 ## change the name of the output root file, default = wcsim.root
-
 /WCSimIO/RootFile wcsim.root
+
+## Boolean to select whether to save the NEUT RooTracker vertices in the output file, provided you used
+## a NEUT vector file as input
+#/WCSimIO/SaveRooTracker 1
 
 /run/beamOn 10
 #exit

--- a/src/TJNuBeamFlux.cc
+++ b/src/TJNuBeamFlux.cc
@@ -1,0 +1,111 @@
+#include "TJNuBeamFlux.hh"
+#include <iostream>
+
+//_______________________________________________________________________________________
+RooTrackerVtxBase::RooTrackerVtxBase() :
+    TObject()
+{
+}
+//_______________________________________________________________________________________
+JNuBeamFlux::JNuBeamFlux() :
+    RooTrackerVtxBase()
+{
+    NuFileName = new TObjString("Not-set");
+    this->Reset();
+}
+//_______________________________________________________________________________________
+JNuBeamFlux::~JNuBeamFlux()
+{
+    if(NuFileName != NULL) { delete NuFileName; NuFileName = NULL; }     
+}
+//_______________________________________________________________________________________
+void JNuBeamFlux::Copy(const JNuBeamFlux * flux)
+{ 
+    NuFileName->SetString(flux->NuFileName->GetString()); 
+    NuFluxEntry = flux->NuFluxEntry;
+    NuParentPdg = flux->NuParentPdg; 
+    NuParentDecMode = flux->NuParentDecMode;
+    NuCospibm = flux->NuCospibm;
+    NuNorm = flux->NuNorm;
+    NuCospi0bm = flux->NuCospi0bm;
+    NuRnu = flux->NuRnu;
+    NuIdfd = flux->NuIdfd;
+    NuGipart = flux->NuGipart;
+    NuGamom0 = flux->NuGamom0;
+    NuEnusk = flux->NuEnusk; 
+    NuNormsk = flux->NuNormsk; 
+    NuAnorm = flux->NuAnorm; 
+    NuVersion = flux->NuVersion; 
+    NuTuneid = flux->NuTuneid; 
+    NuNtrig = flux->NuNtrig; 
+    NuPint = flux->NuPint;  
+    NuRand = flux->NuRand; 
+    for(int i=0;i<2;i++){
+        NuXnu [i] = flux->NuXnu[i];  
+        NuBpos[i] = flux->NuBpos[i]; 
+        NuBtilt[i] = flux->NuBtilt[i]; 
+        NuBrms[i] = flux->NuBrms[i]; 
+        NuEmit[i] = flux->NuEmit[i];
+        NuAlpha[i] = flux->NuAlpha[i]; 
+    } 
+    for(int i=0;i<3;i++){
+        NuGpos0[i] = flux->NuGpos0[i]; 
+        NuGvec0[i] = flux->NuGvec0[i];
+        NuHcur[i] = flux->NuHcur[i];
+    } 
+    for(int i=0;i<4;i++){
+        NuParentDecP4[i] = flux->NuParentDecP4[i]; 
+        NuParentDecX4[i] = flux->NuParentDecX4[i]; 
+        NuParentProP4[i] = flux->NuParentProP4[i]; 
+        NuParentProX4[i] = flux->NuParentProX4[i];
+    }
+    NuNg = flux->NuNg;
+    for(int i=0;i<kNgmax;i++){
+        NuGcosbm[i] = flux->NuGcosbm[i]; 
+        NuGdistc[i] = flux->NuGdistc[i]; 
+        NuGdistal[i] = flux->NuGdistal[i]; 
+        NuGdistti[i] = flux->NuGdistti[i]; 
+        NuGdistfe[i] = flux->NuGdistfe[i];   
+        NuGpid[i] = flux->NuGpid[i];
+        NuGmec[i] = flux->NuGmec[i]; 
+        NuGmat[i] = flux->NuGmat[i]; 
+        for(int j=0;j<3;j++) {
+            NuGp[i][j] = flux->NuGp[i][j];
+            NuGv[i][j] = flux->NuGv[i][j];
+        }
+    }
+}
+//_______________________________________________________________________________________
+void JNuBeamFlux::Reset()
+{
+    NuFluxEntry = -1;
+    NuFileName->SetString("Not-set"); 
+
+    NuParentPdg = 0; 
+    NuParentDecMode = -1;
+    NuCospibm = NuNorm = NuCospi0bm = NuRnu = -999999.;
+    NuIdfd = NuGipart = -999999;
+    NuGamom0 = NuEnusk = NuNormsk = NuAnorm = NuVersion = -999999.;
+    NuTuneid = NuNtrig = NuPint = NuRand = -999999;
+    for(int i=0;i<2;i++){
+        NuXnu [i] = NuBpos[i] = NuBtilt[i] = NuBrms[i] = NuEmit[i] = NuAlpha[i] = -999999.;
+    }
+    for(int i=0;i<3;i++) NuGpos0[i] = NuGvec0[i] = NuHcur[i] = -999999.; 
+    for(int i=0;i<4;i++) NuParentDecP4[i] = NuParentDecX4[i] = NuParentProP4[i] = NuParentProX4[i] = -999999.; 
+    NuNg = -1;
+    for(int i=0;i<kNgmax;i++){
+        NuGcosbm[i] = NuGdistc[i] = NuGdistal[i] = NuGdistti[i] = NuGdistfe[i] = -999999.;  
+        NuGpid[i] = 0;
+        NuGmec[i] = NuGmat[i] = -999999;
+        for(int j=0;j<3;j++){ 
+            NuGv[i][j] = -999999.;
+            NuGp[i][j] = -999999.;
+        }
+    }
+}
+//_______________________________________________________________________________________
+
+ClassImp(RooTrackerVtxBase);
+ClassImp(JNuBeamFlux);
+
+

--- a/src/TNRooTrackerVtx.cc
+++ b/src/TNRooTrackerVtx.cc
@@ -1,0 +1,368 @@
+#include <iomanip>
+#include <iostream>
+
+#include "TNRooTrackerVtx.hh"
+
+using std::endl;
+using std::cout;
+using std::setw;
+using std::setprecision;
+using std::setfill;
+using std::ios;
+
+ClassImp(NRooTrackerVtx)
+
+//_______________________________________________________________________________________
+NRooTrackerVtx::NRooTrackerVtx() :
+        JNuBeamFlux()
+{
+    this->Init();
+}
+//_______________________________________________________________________________________
+NRooTrackerVtx::~NRooTrackerVtx()
+{
+    if(GeomPath      != NULL) { delete GeomPath;      GeomPath      = NULL; }     
+    if(GeneratorName != NULL) { delete GeneratorName; GeneratorName = NULL; }     
+    if(EvtCode       != NULL) { delete EvtCode;       EvtCode       = NULL; }     
+    if(OrigFileName  != NULL) { delete OrigFileName;  OrigFileName  = NULL; }     
+    if(OrigTreeName  != NULL) { delete OrigTreeName;  OrigTreeName  = NULL; }     
+}
+//_______________________________________________________________________________________
+void NRooTrackerVtx::Copy(const NRooTrackerVtx * event)
+{ 
+    GeomPath->SetString(event->GeomPath->GetString());
+    GeneratorName->SetString(event->GeneratorName->GetString());
+    EvtCode->SetString(event->EvtCode->GetString());
+    OrigFileName->SetString(event->OrigFileName->GetString());
+    OrigTreeName->SetString(event->OrigTreeName->GetString());
+
+    EvtNum    = event->EvtNum;  
+    EvtXSec   = event->EvtXSec; 
+    EvtDXSec  = event->EvtDXSec; 
+    EvtWght   = event->EvtWght;   
+    EvtProb   = event->EvtProb;   
+    OrigTreePOT = event->OrigTreePOT;
+    OrigEvtNum  = event->OrigEvtNum;
+    TimeInSpill  = event->TimeInSpill;
+    OrigTreeEntries  = event->OrigTreeEntries;
+    TruthVertexID = event->TruthVertexID;
+
+    for(int i=0; i < 4; i++) { 
+        EvtVtx[i] = event->EvtVtx[i]; 
+    }
+
+    NuNorm = event->NuNorm;
+    NuEnusk = event->NuEnusk;
+    NuNormsk = event->NuNormsk;
+    NuAnorm = event->NuAnorm;
+
+    StdHepN = event->StdHepN;
+
+    //define the dynamic arrays
+    StdHepPdg = new int[StdHepN];
+    StdHepStatus = new int[StdHepN];
+    StdHepFd = new int[StdHepN];
+    StdHepLd = new int[StdHepN];
+    StdHepFm = new int[StdHepN];
+    StdHepLm = new int[StdHepN];
+
+    for(int i=0; i< StdHepN; i++) 
+    {
+        StdHepPdg   [i] = event->StdHepPdgTemp    [i];     
+        StdHepStatus[i] = event->StdHepStatusTemp [i];    
+
+        StdHepFd  [i] = event->StdHepFdTemp   [i];    
+        StdHepLd  [i] = event->StdHepLdTemp   [i];    
+        StdHepFm  [i] = event->StdHepFmTemp   [i];    
+        StdHepLm  [i] = event->StdHepLmTemp   [i];    
+
+        for(int j=0; j < 4; j++) { StdHepX4   [i][j] = event->StdHepX4   [i][j]; }
+        for(int j=0; j < 4; j++) { StdHepP4   [i][j] = event->StdHepP4   [i][j]; }
+        for(int j=0; j < 3; j++) { StdHepPolz [i][j] = event->StdHepPolz [i][j]; }
+    }
+
+    NEnvc = event->NEnvc;
+
+    //define the dynamic arrays
+    NEipvc = new int[NEnvc];
+    NEiorgvc = new int[NEnvc];
+    NEiflgvc = new int[NEnvc];
+    NEicrnvc = new int[NEnvc];
+
+    for(int i=0; i< NEnvc; i++) {
+        NEipvc[i] = event->NEipvcTemp[i];
+        NEiorgvc[i] = event->NEiorgvcTemp[i];
+        NEiflgvc[i] = event->NEiflgvcTemp[i];
+        NEicrnvc[i] = event->NEicrnvcTemp[i];
+        for(int j=0; j < 3; j++) { NEpvc[i][j] = event->NEpvc[i][j]; } 
+    }
+
+    NEcrsx = event->NEcrsx;
+    NEcrsy = event->NEcrsy;
+    NEcrsz = event->NEcrsz;
+    NEcrsphi = event->NEcrsphi;
+
+    NEnvert = event->NEnvert;
+    //define the dynamic array
+    NEiflgvert = new int[NEnvert];
+    for(int i=0; i< NEnvert; i++) {
+        NEiflgvert[i] = event->NEiflgvertTemp[i] ;
+        for(int j=0; j < 3; j++) { NEposvert[i][j] = event->NEposvert[i][j]; }
+    }
+
+    NEnvcvert = event->NEnvcvert;
+
+    //define the dynamic arrays
+    NEabspvert = new float[NEnvcvert];
+    NEabstpvert = new float[NEnvcvert];
+    NEipvert = new int[NEnvcvert];
+    NEiverti = new int[NEnvcvert];
+    NEivertf = new int[NEnvcvert];
+
+    for(int i=0; i< NEnvcvert; i++) {
+        NEabspvert[i] = event->NEabspvertTemp[i];
+        NEabstpvert[i] = event->NEabstpvertTemp[i];
+        NEipvert[i] = event->NEipvertTemp[i];
+        NEiverti[i] = event->NEivertiTemp[i];
+        NEivertf[i] = event->NEivertfTemp[i];
+        for(int j=0; j < 3; j++) { NEdirvert[i][j] = event->NEdirvert[i][j]; }
+    }
+
+    // Remember to copy the flux info
+    JNuBeamFlux * flux = (JNuBeamFlux*) event;
+    JNuBeamFlux::Copy(flux);
+
+}
+//_______________________________________________________________________________________
+void NRooTrackerVtx::Reset()
+{
+
+    if (GeomPath     ) GeomPath      -> SetString("Not-set");  
+    if (GeneratorName) GeneratorName -> SetString("Not-set");  
+    if (EvtCode      ) EvtCode       -> SetString("Not-set");             
+    if (OrigFileName ) OrigFileName   -> SetString("Not-set");             
+    if (OrigTreeName ) OrigTreeName  -> SetString("Not-set");             
+
+    EvtNum   = -1;                  
+    EvtXSec  = -1.0;                
+    EvtDXSec = -1.0;         
+    EvtWght  = -1.0;         
+    EvtProb  = -1.0;                
+    OrigTreePOT = -1.0;
+    OrigEvtNum  = -1;
+    TimeInSpill  = -1.0;
+    OrigTreeEntries  = -1;
+    TruthVertexID = -1;  
+
+    for(int i=0; i < 4; i++){
+        EvtVtx[i] = 0.0;
+    }
+
+    StdHepN = 0;
+
+    for(int i=0; i<kNStdHepNPmax; i++) 
+    {
+        //If the arrays are dynamic, only reset the Temp version of the data member
+        StdHepPdgTemp   [i] = -1;     
+        StdHepStatusTemp[i] = -1;    
+        StdHepFdTemp  [i] = -1;    
+        StdHepLdTemp  [i] = -1;    
+        StdHepFmTemp  [i] = -1;    
+        StdHepLmTemp  [i] = -1;    
+        for(int j=0; j < 4; j++) { StdHepX4    [i][j] = 0; }
+        for(int j=0; j < 4; j++) { StdHepP4    [i][j] = 0; }
+        for(int j=0; j < 3; j++) { StdHepPolz  [i][j] = 0; }
+    }
+
+    NEnvc = 0;
+    for(int ip = 0; ip < kNEmaxvc; ip++){
+        NEipvcTemp[ip] = -1;
+        NEiorgvcTemp[ip] = -1;
+        NEiflgvcTemp[ip] = -1;
+        NEicrnvcTemp[ip] = -1;
+        for(int ip2 = 0; ip2 < 3; ip2++){
+            NEpvc[ip][ip2] = -99999.9;
+        }
+    }
+
+    NEcrsx = -99999.9;
+    NEcrsy = -99999.9;
+    NEcrsz = -99999.9;
+    NEcrsphi = -99999.9;
+
+    NEnvert = 0;
+    for(int iv = 0; iv < kNEmaxvert; iv++){
+        NEiflgvertTemp[iv] = -999;
+        for(int ip2 = 0; ip2 < 3; ip2++){
+            NEposvert[iv][ip2] = -999;
+        }
+    }
+
+    NEnvcvert = 0;  
+    for(int ip = 0; ip < kNEmaxvertp; ip++){
+        NEabspvertTemp[ip] = -99999.9;
+        NEabstpvertTemp[ip] = -99999.9;
+        NEipvertTemp[ip] = -1;
+        NEivertiTemp[ip] = -1;
+        NEivertfTemp[ip] = -1;
+        for(int ip2 = 0; ip2 < 3; ip2++){
+            NEdirvert[ip][ip2] = -99999.9;
+        }
+    }
+
+}
+//_______________________________________________________________________________________
+void NRooTrackerVtx::Init()
+{
+    GeomPath      = new TObjString("");
+    GeneratorName = new TObjString("");
+    EvtCode       = new TObjString(""); 
+    OrigFileName  = new TObjString(""); 
+    OrigTreeName  = new TObjString(""); 
+
+    this->Reset();
+}
+//_______________________________________________________________________________________
+void NRooTrackerVtx::Print(const Option_t*) const
+{
+
+    cout << "\nNRooTrackerMCTruth: "    << endl;
+    cout << "  --> GeneratorName = " << GeneratorName->GetString() << endl;
+    cout << "  --> EvtCode       = " << EvtCode->GetString() << endl;
+    cout << "  --> GeomPath      = " << GeomPath->GetString() << endl;
+    cout << "  --> EvtNum        = " << EvtNum << endl;
+    cout << "  --> EvtXSec       = " << EvtXSec << endl;
+    cout << "  --> EvtDXSec      = " << EvtDXSec << endl;
+    cout << "  --> EvtWght       = " << EvtWght << endl;
+    cout << "  --> EvtProb       = " << EvtProb << endl;
+    cout << "  --> TruthVertexID = " << TruthVertexID << endl;
+
+
+    cout << "NRooTrackerStdHep:" << endl;
+
+    for(int i=0; i<StdHepN; i++) {
+        cout 
+            << setfill(' ') << setw(4)  << i 
+            << " -> pdgc: " 
+            << " / ist: " 
+            << setfill(' ') << setw(3) << StdHepStatus[i] 
+            << " / mom: "
+            << setfill(' ') << setw(3) << StdHepFm[i]   
+            << " / daughters: (" 
+            << setfill(' ') << setw(3) << StdHepFd[i] 
+            << ", " 
+            << setfill(' ') << setw(3) << StdHepLd[i] 
+            << ") / E = " 
+            << setfill(' ') << setw(10) << StdHepP4[i][kNStdHepIdxE] 
+            << ", px = " 
+            << setfill(' ') << setw(10) << StdHepP4[i][kNStdHepIdxPx] 
+            << ", py = " 
+            << setfill(' ') << setw(10) << StdHepP4[i][kNStdHepIdxPy] 
+            << ", pz = " 
+            << setfill(' ') << setw(10) << StdHepP4[i][kNStdHepIdxPz] 
+            << endl;
+    }
+
+    cout << endl << "Jnu-beam pass through info:" << endl;
+    cout << "  -->  NuParentPdg      = " << NuParentPdg << endl;
+    cout << "  -->  NuParentDecMode  = " << NuParentDecMode << endl;
+    cout << "  -->  NuParentDecP4[4] = " << NuParentDecP4[0] << ", "<< NuParentDecP4[1] << ", " << NuParentDecP4[2] << ", " << NuParentDecP4[3] << endl;
+    cout << "  -->  NuParentDecX4[4] = " << NuParentDecX4[0] << ", "<< NuParentDecX4[1] << ", " << NuParentDecX4[2] << ", " << NuParentDecX4[3] << endl;
+    cout << "  -->  NuParentProP4[4] = " << NuParentProP4[0] << ", "<< NuParentProP4[1] << ", " << NuParentProP4[2] << ", " << NuParentProP4[3] << endl;
+    cout << "  -->  NuParentProX4[4] = " << NuParentProX4[0] << ", "<< NuParentProX4[1] << ", " << NuParentProX4[2] << ", " << NuParentProX4[3] << endl;
+    cout << "  -->  NuGipart         = " << NuGipart << endl;
+    cout << "  -->  NuGamom0         = " << NuGamom0 << endl;
+    cout << "  -->  NuGpos0[3] = " << NuGpos0[0] << ", "<< NuGpos0[1] << ", " << NuGpos0[2] << endl; 
+    cout << "  -->  NuGvec0[3] = " << NuGvec0[0] << ", "<< NuGvec0[1] << ", " << NuGvec0[2] << endl; 
+
+    cout << "NuEnusk = " << NuEnusk << endl;
+    cout << "NuNorm = " << NuNorm << endl;
+    cout << "NuNormsk = " << NuNormsk << endl;
+    cout << "NuAnorm = " << NuAnorm << endl;
+
+    cout << "NuVersion = " << NuVersion << endl;
+    cout << "NuTuneid = " << NuTuneid << endl;;
+    cout << "NuPint = " << NuPint << endl;
+
+    cout << "NuBpos[2] = ";
+    for(int ip = 0; ip < 2; ip++)
+        cout << NuBpos[ip] << " ";
+    cout << endl;
+
+    cout << "NuBtilt[2] = ";
+    for(int ip = 0; ip < 2; ip++)
+        cout << NuBtilt[ip] << " ";
+    cout << endl;
+
+    cout << "NuBrms[2] = ";
+    for(int ip = 0; ip < 2; ip++)
+        cout << NuBrms[ip] << " ";
+    cout << endl;
+
+    cout << "NuEmit[2] = ";
+    for(int ip = 0; ip < 2; ip++)
+        cout << NuEmit[ip] << " ";
+    cout << endl;
+
+    cout << "NuAlpha[2] = ";
+    for(int ip = 0; ip < 2; ip++)
+        cout << NuAlpha[ip] << " ";
+    cout << endl;
+
+    cout << "NuHcur[3] = "; 
+    for(int ip = 0; ip < 3; ip++)
+        cout << NuHcur[ip] << " "; 
+    cout << endl;
+
+
+    cout << endl << "NEUT pass through info:" << endl << endl;
+
+    cout << "NEnvc = " << NEnvc << endl;
+    cout << "ip NEipvc[ip] NEiorgvc[ip] NEiflgvc[ip] NEicrnvc[ip] NEpvc[ip][3]" << endl;
+    for(int ip = 0; ip < NEnvc; ip++) {
+        cout << ip << " " << NEipvc[ip] << " " << NEiorgvc[ip] << " ";
+        cout << NEiflgvc[ip] << " " << NEicrnvc[ip] << " ";
+        for(int ip2 = 0; ip2 < 3; ip2++){
+            cout << NEpvc[ip][ip2] << " ";
+        }
+        cout << endl;
+    }
+    cout << endl;
+
+    cout << "NEcrsx NEcrsy NEcrsz NEcrsphi" << endl;
+    cout << NEcrsx << " " << NEcrsy << " " <<  NEcrsz << " " << NEcrsphi << endl;
+
+    cout << "NEnvert = " << NEnvert << endl;
+    cout << "iv NEiflgvert[iv] NEposvert[iv][3]" << endl;
+
+    for(int iv = 0; iv < NEnvert; iv++){
+        cout << iv << " " << NEiflgvert[iv] << " ";
+        for(int ip2 = 0; ip2 < 3; ip2++){
+            cout << NEposvert[iv][ip2] << " ";
+        }
+        cout << endl;
+    }
+    cout << endl;
+
+    cout << "NEnvcvert = " << NEnvcvert << endl;
+    cout << "ip NEabspvert[ip] NEabstpvert[ip] NEipvert[ip] NEiverti[ip] NEivertf[ip] NEdirvert[ip][3]" << endl;
+    for(int ip = 0; ip < NEnvcvert; ip++){
+        cout << ip << " " << NEabspvert[ip] << " " <<   NEabstpvert[ip] << " " <<  NEipvert[ip] << " " << NEiverti[ip] << " " << NEivertf[ip] << " ";
+        for(int ip2 = 0; ip2 < 3; ip2++){
+            cout << NEdirvert[ip][ip2] << " ";
+        }
+        cout << endl;
+    }
+    cout << endl;
+
+    cout << endl << "Pass-through file info:" << endl;
+    cout << "  --> OrigFileName       = " << OrigFileName->GetString() << endl;
+    cout << "  --> OrigTreeName       = " << OrigTreeName->GetString() << endl;
+    cout << "  --> OrigEvtNum         = " << OrigEvtNum << endl;
+    cout << "  --> TimeInSpill         = " << TimeInSpill << endl;
+    cout << "  --> OrigTreeEntries    = " << OrigTreeEntries << endl;
+    cout << "  --> OrigTreePOT        = " << OrigTreePOT << endl;
+
+}
+//_______________________________________________________________________________________
+

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -289,6 +289,10 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
 		WCHC,
 		WCDC);
 
+  if(generatorAction->IsUsingNeutEvtGenerator()){
+      CopyNRooTrackerVtx();
+  }
+
 }
 
 G4int WCSimEventAction::WCSimEventFindStartingVolume(G4ThreeVector vtx)
@@ -748,3 +752,20 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
   wcsimrootsuperevent->ReInitialize();
   
 }
+
+void WCSimEventAction::CopyNRooTrackerVtx()
+{
+  TNRooTrackerVtx* vtx = generatorAction->GetNRooTrackerVtx();
+
+  //Save NEUT vertex truth info in TClonesArray entry 
+  TNRooTrackerVtx* currNeutVtx = new((*fVertices)[fNVtx])NRooTrackerVtx(); 
+  fNVtx += 1; 
+  currNeutVtx->Copy(vtx); 
+  // May want to use this variable for truth matching later
+  currNeutVtx->TruthVertexID = -999;
+                      
+
+
+
+
+

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -281,18 +281,12 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
    // G4cout << "FGDyHC: " << &FGDyHC << G4endl;
    // G4cout << "MRDxHC: " << &MRDxHC << G4endl;
    // G4cout << "MRDyHC: " << &MRDyHC << G4endl;
-   
 
   FillRootEvent(event_id,
 		jhfNtuple,
 		trajectoryContainer,
 		WCHC,
 		WCDC);
-
-  if(generatorAction->IsUsingNeutEvtGenerator()){
-      CopyNRooTrackerVtx();
-  }
-
 }
 
 G4int WCSimEventAction::WCSimEventFindStartingVolume(G4ThreeVector vtx)
@@ -747,25 +741,17 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
   // as we have events. All the intermediate copies are incomplete, only the
   // last one is useful --> huge waste of disk space.
   hfile->Write("",TObject::kOverwrite);
+
+  // Check we are supposed to be saving the NEUT vertex and that the generator was given a NEUT vector file to process
+  // If there is no NEUT vector file an empty NEUT vertex will be written to the output file
+  if(GetRunAction()->GetSaveRooTracker() && generatorAction->IsUsingNeutEvtGenerator()){
+      generatorAction->CopyNeutVertex(GetRunAction()->GetNeutVertex());
+      GetRunAction()->FillNeutVertexTree();
+      GetRunAction()->ClearNeutVertexArray();
+  }
   
   // M Fechner : reinitialize the super event after the writing is over
   wcsimrootsuperevent->ReInitialize();
   
 }
-
-void WCSimEventAction::CopyNRooTrackerVtx()
-{
-  TNRooTrackerVtx* vtx = generatorAction->GetNRooTrackerVtx();
-
-  //Save NEUT vertex truth info in TClonesArray entry 
-  TNRooTrackerVtx* currNeutVtx = new((*fVertices)[fNVtx])NRooTrackerVtx(); 
-  fNVtx += 1; 
-  currNeutVtx->Copy(vtx); 
-  // May want to use this variable for truth matching later
-  currNeutVtx->TruthVertexID = -999;
-                      
-
-
-
-
 

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -744,10 +744,10 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 
   // Check we are supposed to be saving the NEUT vertex and that the generator was given a NEUT vector file to process
   // If there is no NEUT vector file an empty NEUT vertex will be written to the output file
-  if(GetRunAction()->GetSaveRooTracker() && generatorAction->IsUsingNeutEvtGenerator()){
-      generatorAction->CopyNeutVertex(GetRunAction()->GetNeutVertex());
-      GetRunAction()->FillNeutVertexTree();
-      GetRunAction()->ClearNeutVertexArray();
+  if(GetRunAction()->GetSaveRooTracker() && generatorAction->IsUsingRootrackerEvtGenerator()){
+      generatorAction->CopyRootrackerVertex(GetRunAction()->GetRootrackerVertex());
+      GetRunAction()->FillRootrackerVertexTree();
+      GetRunAction()->ClearRootrackerVertexArray();
   }
   
   // M Fechner : reinitialize the super event after the writing is over

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -25,269 +25,452 @@ vector<string> tokenize( string separators, string input );
 
 inline vector<string> readInLine(fstream& inFile, int lineSize, char* inBuf)
 {
-  // Read in line break it up into tokens
-  inFile.getline(inBuf,lineSize);
-  return tokenize(" $", inBuf);
+    // Read in line break it up into tokens
+    inFile.getline(inBuf,lineSize);
+    return tokenize(" $", inBuf);
 }
 
 inline float atof( const string& s ) {return std::atof( s.c_str() );}
 inline int   atoi( const string& s ) {return std::atoi( s.c_str() );}
 
 WCSimPrimaryGeneratorAction::WCSimPrimaryGeneratorAction(
-					  WCSimDetectorConstruction* myDC)
-  :myDetector(myDC)
+        WCSimDetectorConstruction* myDC)
+:myDetector(myDC)
 {
-  //T. Akiri: Initialize GPS to allow for the laser use 
-  MyGPS = new G4GeneralParticleSource();
+    //T. Akiri: Initialize GPS to allow for the laser use 
+    MyGPS = new G4GeneralParticleSource();
 
-  // Initialize to zero
-  mode = 0;
-  vtxvol = 0;
-  vtx = G4ThreeVector(0.,0.,0.);
-  nuEnergy = 0.;
-  _counterRock=0; // counter for generated in Rock
-  _counterCublic=0; // counter generated
-  
-  //---Set defaults. Do once at beginning of session.
-  
-  G4int n_particle = 1;
-  particleGun = new G4ParticleGun(n_particle);
-  particleGun->SetParticleEnergy(1.0*GeV);
-  particleGun->SetParticleMomentumDirection(G4ThreeVector(0.,0.,1.0));
+    // Initialize to zero
+    mode = 0;
+    vtxvol = 0;
+    vtx = G4ThreeVector(0.,0.,0.);
+    nuEnergy = 0.;
+    _counterRock=0; // counter for generated in Rock
+    _counterCublic=0; // counter generated
 
-  G4ParticleTable* particleTable = G4ParticleTable::GetParticleTable();
-  G4String particleName;
-  particleGun->
-    SetParticleDefinition(particleTable->FindParticle(particleName="mu+"));
+    //---Set defaults. Do once at beginning of session.
 
-  particleGun->
-    SetParticlePosition(G4ThreeVector(0.*m,0.*m,0.*m));
-    
-  messenger = new WCSimPrimaryGeneratorMessenger(this);
-  useMulineEvt = true;
-  useNormalEvt = false;
+    G4int n_particle = 1;
+    particleGun = new G4ParticleGun(n_particle);
+    particleGun->SetParticleEnergy(1.0*GeV);
+    particleGun->SetParticleMomentumDirection(G4ThreeVector(0.,0.,1.0));
+
+    G4ParticleTable* particleTable = G4ParticleTable::GetParticleTable();
+    G4String particleName;
+    particleGun->
+        SetParticleDefinition(particleTable->FindParticle(particleName="mu+"));
+
+    particleGun->
+        SetParticlePosition(G4ThreeVector(0.*m,0.*m,0.*m));
+
+    messenger = new WCSimPrimaryGeneratorMessenger(this);
+
+    useMulineEvt = true;
+    useNeutEvt = false;
+    useNormalEvt = false;
+    useLaserEvt = false;
+
+    fEvNum = 0;
+    fRooTrackerTree = NULL;
+    fInputNeutFile = NULL;
+    fNEntries = 0;
 }
 
 WCSimPrimaryGeneratorAction::~WCSimPrimaryGeneratorAction()
 {
-  if (IsGeneratingVertexInRock()){
-    G4cout << "Fraction of Rock volume is : " << G4endl;
-      G4cout << " Random number generated in Rock / in Cublic = " 
-             << _counterRock << "/" << _counterCublic 
-             << " = " << _counterRock/(G4double)_counterCublic << G4endl;
-  }
-  inputFile.close();
-  delete particleGun;
-  delete MyGPS;   //T. Akiri: Delete the GPS variable
-  delete messenger;
+    if (IsGeneratingVertexInRock()){
+        G4cout << "Fraction of Rock volume is : " << G4endl;
+        G4cout << " Random number generated in Rock / in Cublic = " 
+            << _counterRock << "/" << _counterCublic 
+            << " = " << _counterRock/(G4double)_counterCublic << G4endl;
+    }
+    inputFile.close();
+
+    if(useNeutEvt) delete fRooTrackerTree;
+
+    delete particleGun;
+    delete MyGPS;   //T. Akiri: Delete the GPS variable
+    delete messenger;
 }
 
 void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 {
 
-  // We will need a particle table
-  G4ParticleTable* particleTable = G4ParticleTable::GetParticleTable();
+    // We will need a particle table
+    G4ParticleTable* particleTable = G4ParticleTable::GetParticleTable();
 
-  // Temporary kludge to turn on/off vector text format 
+    // Temporary kludge to turn on/off vector text format 
+    G4bool useNuanceTextFormat = true;
 
-  G4bool useNuanceTextFormat = true;
+    // Do for every event
+    if (useMulineEvt)
+    { 
+
+        if ( !inputFile.is_open() )
+        {
+            G4cout << "Set a vector file using the command /mygen/vecfile name"
+                << G4endl;
+            return;
+        }
+
+        if (useNuanceTextFormat)
+        {
+            const int lineSize=100;
+            char      inBuf[lineSize];
+            vector<string> token(1);
+
+            token = readInLine(inputFile, lineSize, inBuf);
+
+            if (token.size() == 0) 
+            {
+                G4cout << "end of nuance vector file!" << G4endl;
+            }
+            else if (token[0] != "begin")
+            {
+                G4cout << "unexpected line begins with " << token[0] << G4endl;
+            }
+            else   // normal parsing begins here
+            {
+                // Read the nuance line (ignore value now)
+
+                token = readInLine(inputFile, lineSize, inBuf);
+                mode = atoi(token[1]);
+
+                // Read the Vertex line
+                token = readInLine(inputFile, lineSize, inBuf);
+                vtx = G4ThreeVector(atof(token[1])*cm,
+                        atof(token[2])*cm,
+                        atof(token[3])*cm);
+
+                // true : Generate vertex in Rock , false : Generate vertex in WC tank
+                SetGenerateVertexInRock(false);
+
+                // Next we read the incoming neutrino and target
+
+                // First, the neutrino line
+
+                token=readInLine(inputFile, lineSize, inBuf);
+                beampdg = atoi(token[1]);
+                beamenergy = atof(token[2])*MeV;
+                beamdir = G4ThreeVector(atof(token[3]),
+                        atof(token[4]),
+                        atof(token[5]));
+
+                // Now read the target line
+
+                token=readInLine(inputFile, lineSize, inBuf);
+                targetpdg = atoi(token[1]);
+                targetenergy = atof(token[2])*MeV;
+                targetdir = G4ThreeVector(atof(token[3]),
+                        atof(token[4]),
+                        atof(token[5]));
+
+                // Read the info line, basically a dummy
+                token=readInLine(inputFile, lineSize, inBuf);
+                G4cout << "Vector File Record Number " << token[2] << G4endl;
+                vecRecNumber = atoi(token[2]);
+
+                // Now read the outgoing particles
+                // These we will simulate.
 
 
-  // Do for every event
+                while ( token=readInLine(inputFile, lineSize, inBuf),
+                        token[0] == "track" )
+                {
+                    // We are only interested in the particles
+                    // that leave the nucleus, tagged by "0"
 
-  if (useMulineEvt)
-  { 
 
-    if ( !inputFile.is_open() )
-    {
-      G4cout << "Set a vector file using the command /mygen/vecfile name"
-	     << G4endl;
-      return;
+                    if ( token[6] == "0")
+                    {
+                        G4int pdgid = atoi(token[1]);
+                        G4double energy = atof(token[2])*MeV;
+                        G4ThreeVector dir = G4ThreeVector(atof(token[3]),
+                                atof(token[4]),
+                                atof(token[5]));
+                        particleGun->
+                            SetParticleDefinition(particleTable->
+                                    FindParticle(pdgid));
+                        G4double mass = 
+                            particleGun->GetParticleDefinition()->GetPDGMass();
+
+                        G4double ekin = energy - mass;
+
+                        particleGun->SetParticleEnergy(ekin);
+                        //G4cout << "Particle: " << pdgid << " KE: " << ekin << G4endl;
+                        particleGun->SetParticlePosition(vtx);
+                        particleGun->SetParticleMomentumDirection(dir);
+                        particleGun->GeneratePrimaryVertex(anEvent);
+                    }
+                }
+            }
+        }
+        else 
+        {    // old muline format  
+            inputFile >> nuEnergy >> energy >> xPos >> yPos >> zPos 
+                >> xDir >> yDir >> zDir;
+
+            G4double random_z = ((myDetector->GetWaterTubePosition())
+                    - .5*(myDetector->GetWaterTubeLength()) 
+                    + 1.*m + 15.0*m*G4UniformRand())/m;
+            zPos = random_z;
+            G4ThreeVector vtx = G4ThreeVector(xPos, yPos, random_z);
+            G4ThreeVector dir = G4ThreeVector(xDir,yDir,zDir);
+
+            particleGun->SetParticleEnergy(energy*MeV);
+            particleGun->SetParticlePosition(vtx);
+            particleGun->SetParticleMomentumDirection(dir);
+            particleGun->GeneratePrimaryVertex(anEvent);
+        }
     }
 
-    if (useNuanceTextFormat)
-      {
-	const int lineSize=100;
-	char      inBuf[lineSize];
-	vector<string> token(1);
-	
-	token = readInLine(inputFile, lineSize, inBuf);
-	  
-        if (token.size() == 0) 
-	  {
-	    G4cout << "end of nuance vector file!" << G4endl;
-	  }
-	else if (token[0] != "begin")
-	  {
-	    G4cout << "unexpected line begins with " << token[0] << G4endl;
-	  }
-	else   // normal parsing begins here
-	  {
-	    // Read the nuance line (ignore value now)
+    else if (useNeutEvt)
+    { 
+        if ( !inputFile.is_open() )
+        {
+            G4cout << "Set a NEUT vector file using the command /mygen/vecfile name"
+                << G4endl;
+            return;
+        }
 
-	    token = readInLine(inputFile, lineSize, inBuf);
-	    mode = atoi(token[1]);
+        fNVtx = 0;
 
-	    // Read the Vertex line
-	    token = readInLine(inputFile, lineSize, inBuf);
-	    vtx = G4ThreeVector(atof(token[1])*cm,
-				atof(token[2])*cm,
-				atof(token[3])*cm);
-	    
-            // true : Generate vertex in Rock , false : Generate vertex in WC tank
-            SetGenerateVertexInRock(false);
+        //Generate 1 event
+        SetupBranchAddresses(tempVtx); //link tempVtx and current input file
 
-	    // Next we read the incoming neutrino and target
-	    
-	    // First, the neutrino line
+        //Load event from file
+        if (fEvNum<fNEntries){
+            fRooTrackerTree->GetEntry(fEvNum);
+            fEvNum++;
+        }
+        else{
+            G4cout << "End of File" << G4endl; 
+            EndOfFile=true; 
+            G4RunManager::GetRunManager()->AbortRun(); 
+            return; 
+        }
 
-	    token=readInLine(inputFile, lineSize, inBuf);
-	    beampdg = atoi(token[1]);
-	    beamenergy = atof(token[2])*MeV;
-	    beamdir = G4ThreeVector(atof(token[3]),
-				    atof(token[4]),
-				    atof(token[5]));
+        //Position in WCSim coordinates
+        xPos = tempVtx->fEvNumtVtx[0]*m;
+        yPos = tempVtx->fEvNumtVtx[1]*m;
+        zPos = tempVtx->fEvNumtVtx[2]*m;
 
-	    // Now read the target line
+        //Check if event is outside detector; skip to next event if so; keep
+        //loading events until one is found within the detector or there are
+        //no more interaction to simulate for this event.
+        //The current neut vector files do not correspond directly to the detector dimensions, so only keep those events within the detector
+        while (sqrt(pow(xPos,2)+pow(yPos,2))>myDetector->GetWCIDDiameter()/2. || (abs(zPos)>myDetector->GetWCIDHeight()/2)){
+            //Load another event
+            if (fEvNum<fNEntries){
+                fRooTrackerTree->GetEntry(fEvNum);
+                G4cout << "Skipped event# " << fEvNum-1 << " in file " << file << " (event vertex outside detector)" << G4endl;
+                fEvNum++;
+            }
+            else{
+                G4cout << "End of File" << G4endl; 
+                EndOfFile=true; 
+                G4RunManager::GetRunManager()->AbortRun(); 
+                return; 
+            }
+            //Convert coordinates
+            xPos = tempVtx->fEvNumtVtx[0]*m; 
+            yPos = tempVtx->fEvNumtVtx[1]*m; 
+            zPos = tempVtx->fEvNumtVtx[2]*m;
+        }
 
-	    token=readInLine(inputFile, lineSize, inBuf);
-	    targetpdg = atoi(token[1]);
-	    targetenergy = atof(token[2])*MeV;
-	    targetdir = G4ThreeVector(atof(token[3]),
-				      atof(token[4]),
-				      atof(token[5]));
+        //Generate particles
+        //i = 0 is the neutrino
+        //i = 1 is the target nucleus
+        //i = 2 is the target nucleon
+        //i > 2 are the outgoing particles
+        for (int i = 3; i < tempVtx->StdHepN; i++){
 
-	    // Read the info line, basically a dummy
-	    token=readInLine(inputFile, lineSize, inBuf);
-	    G4cout << "Vector File Record Number " << token[2] << G4endl;
-            vecRecNumber = atoi(token[2]);
-	    
-	    // Now read the outgoing particles
-	    // These we will simulate.
+            xDir=tempVtx->StdHepP4[i][0];
+            yDir=tempVtx->StdHepP4[i][1];
+            zDir=tempVtx->StdHepP4[i][2];
 
+            momentum=sqrt(pow(xDir,2)+pow(yDir,2)+pow(zDir,2))*GeV;
 
-	    while ( token=readInLine(inputFile, lineSize, inBuf),
-		    token[0] == "track" )
-	      {
-		// We are only interested in the particles
-		// that leave the nucleus, tagged by "0"
+            Time=GetTime(nBunches,sigma,bunchSep);
 
+            G4ThreeVector vtx = G4ThreeVector(xPos, yPos, zPos);
+            G4ThreeVector dir = G4ThreeVector(xDir, yDir, zDir);
 
-		if ( token[6] == "0")
-		  {
-		    G4int pdgid = atoi(token[1]);
-		    G4double energy = atof(token[2])*MeV;
-		    G4ThreeVector dir = G4ThreeVector(atof(token[3]),
-						      atof(token[4]),
-						      atof(token[5]));
-		    particleGun->
-		      SetParticleDefinition(particleTable->
-					    FindParticle(pdgid));
-		    G4double mass = 
-		      particleGun->GetParticleDefinition()->GetPDGMass();
+            particleGun->SetParticleDefinition(particleTable->FindParticle(tempVtx->StdHepPdg[i]));
+            particleGun->SetParticleMomentum(momentum);
+            particleGun->SetParticlePosition(vtx);
+            particleGun->SetParticleMomentumDirection(dir);
+            particleGun->SetParticleTime(Time);
+            particleGun->GeneratePrimaryVertex(anfEvNument);  //Place vertex in stack
+        }
 
-		    G4double ekin = energy - mass;
+        //Save NEUT vertex truth info in TClonesArray entry
+        //Currently only generating one interaction per event, but
+        //will want multiple interactions when simulating near detectors, therefore use TClonesArray to store NRooTracker objects
+        fCurrNeutVtx = new ((*fVertices)[fNVtx]) NRooTrackerVtx();
+        fNVtx += 1;
+        fCurrNeutVtx->Copy(tempVtx);
+        fCurrNeutVtx->TruthVertexID = -999;
 
-		    particleGun->SetParticleEnergy(ekin);
-		    //G4cout << "Particle: " << pdgid << " KE: " << ekin << G4endl;
-		    particleGun->SetParticlePosition(vtx);
-		    particleGun->SetParticleMomentumDirection(dir);
-		    particleGun->GeneratePrimaryVertex(anEvent);
-		  }
-	      }
-	  }
-      }
-    else 
-      {    // old muline format  
-	inputFile >> nuEnergy >> energy >> xPos >> yPos >> zPos 
-		  >> xDir >> yDir >> zDir;
-	
-	G4double random_z = ((myDetector->GetWaterTubePosition())
-			     - .5*(myDetector->GetWaterTubeLength()) 
-			     + 1.*m + 15.0*m*G4UniformRand())/m;
-	zPos = random_z;
-	G4ThreeVector vtx = G4ThreeVector(xPos, yPos, random_z);
-	G4ThreeVector dir = G4ThreeVector(xDir,yDir,zDir);
+        //Add event to truth info tree
+        fRooTrackerOutputTree->Fill();
+        fVertices->Clear();
+    }
 
-	particleGun->SetParticleEnergy(energy*MeV);
-	particleGun->SetParticlePosition(vtx);
-	particleGun->SetParticleMomentumDirection(dir);
-	particleGun->GeneratePrimaryVertex(anEvent);
-      }
-  }
+    else if (useNormalEvt)
+    {      // manual gun operation
+        particleGun->GeneratePrimaryVertex(anEvent);
 
-  else if (useNormalEvt)
-  {      // manual gun operation
-    particleGun->GeneratePrimaryVertex(anEvent);
+        G4ThreeVector P  =anEvent->GetPrimaryVertex()->GetPrimary()->GetMomentum();
+        G4ThreeVector vtx=anEvent->GetPrimaryVertex()->GetPosition();
+        G4double m       =anEvent->GetPrimaryVertex()->GetPrimary()->GetMass();
+        G4int pdg        =anEvent->GetPrimaryVertex()->GetPrimary()->GetPDGcode();
 
-    G4ThreeVector P  =anEvent->GetPrimaryVertex()->GetPrimary()->GetMomentum();
-    G4ThreeVector vtx=anEvent->GetPrimaryVertex()->GetPosition();
-    G4double m       =anEvent->GetPrimaryVertex()->GetPrimary()->GetMass();
-    G4int pdg        =anEvent->GetPrimaryVertex()->GetPrimary()->GetPDGcode();
+        G4ThreeVector dir  = P.unit();
+        G4double E         = std::sqrt((P.dot(P))+(m*m));
 
-    G4ThreeVector dir  = P.unit();
-    G4double E         = std::sqrt((P.dot(P))+(m*m));
+        //     particleGun->SetParticleEnergy(E);
+        //     particleGun->SetParticlePosition(vtx);
+        //     particleGun->SetParticleMomentumDirection(dir);
 
-//     particleGun->SetParticleEnergy(E);
-//     particleGun->SetParticlePosition(vtx);
-//     particleGun->SetParticleMomentumDirection(dir);
-
-    SetVtx(vtx);
-    SetBeamEnergy(E);
-    SetBeamDir(dir);
-    SetBeamPDG(pdg);
-  }
-  else if (useLaserEvt)
+        SetVtx(vtx);
+        SetBeamEnergy(E);
+        SetBeamDir(dir);
+        SetBeamPDG(pdg);
+    }
+    else if (useLaserEvt)
     {
-      //T. Akiri: Create the GPS LASER event
-      MyGPS->GeneratePrimaryVertex(anEvent);
-      
-      G4ThreeVector P   =anEvent->GetPrimaryVertex()->GetPrimary()->GetMomentum();
-      G4ThreeVector vtx =anEvent->GetPrimaryVertex()->GetPosition();
-      G4int pdg         =anEvent->GetPrimaryVertex()->GetPrimary()->GetPDGcode();
-      
-      G4ThreeVector dir  = P.unit();
-      G4double E         = std::sqrt((P.dot(P)));
-      
-      SetVtx(vtx);
-      SetBeamEnergy(E);
-      SetBeamDir(dir);
-      SetBeamPDG(pdg);
+        //T. Akiri: Create the GPS LASER event
+        MyGPS->GeneratePrimaryVertex(anEvent);
+
+        G4ThreeVector P   =anEvent->GetPrimaryVertex()->GetPrimary()->GetMomentum();
+        G4ThreeVector vtx =anEvent->GetPrimaryVertex()->GetPosition();
+        G4int pdg         =anEvent->GetPrimaryVertex()->GetPrimary()->GetPDGcode();
+
+        G4ThreeVector dir  = P.unit();
+        G4double E         = std::sqrt((P.dot(P)));
+
+        SetVtx(vtx);
+        SetBeamEnergy(E);
+        SetBeamDir(dir);
+        SetBeamPDG(pdg);
     }
 }
 
 // Returns a vector with the tokens
 vector<string> tokenize( string separators, string input ) 
 {
-  unsigned int startToken = 0, endToken; // Pointers to the token pos
-  vector<string> tokens;  // Vector to keep the tokens
-  
-  if( separators.size() > 0 && input.size() > 0 ) 
+    unsigned int startToken = 0, endToken; // Pointers to the token pos
+    vector<string> tokens;  // Vector to keep the tokens
+
+    if( separators.size() > 0 && input.size() > 0 ) 
     {
-    
-      while( startToken < input.size() )
-	{
-	  // Find the start of token
-	  startToken = input.find_first_not_of( separators, startToken );
-      
-	  // If found...
-	  if( startToken != input.npos ) 
-	    {
-	      // Find end of token
-	      endToken = input.find_first_of( separators, startToken );
-	      if( endToken == input.npos )
-		// If there was no end of token, assign it to the end of string
-		endToken = input.size();
-        
-	      // Extract token
-	      tokens.push_back( input.substr( startToken, endToken - startToken ) );
-        
-	      // Update startToken
-	      startToken = endToken;
-	    }
-	}
+
+        while( startToken < input.size() )
+        {
+            // Find the start of token
+            startToken = input.find_first_not_of( separators, startToken );
+
+            // If found...
+            if( startToken != input.npos ) 
+            {
+                // Find end of token
+                endToken = input.find_first_of( separators, startToken );
+                if( endToken == input.npos )
+                    // If there was no end of token, assign it to the end of string
+                    endToken = input.size();
+
+                // Extract token
+                tokens.push_back( input.substr( startToken, endToken - startToken ) );
+
+                // Update startToken
+                startToken = endToken;
+            }
+        }
     }
-  
-  return tokens;
+
+    return tokens;
+}
+
+void WCSimPrimaryGeneratorAction::InitialiseNeutObjects()
+{
+    //Setup TClonesArray to store NEUT truth info
+    fVertices = new TClonesArray("NRooTrackerVtx", 1);
+    fVertices->BypassStreamer();
+    fVertices->Clear();
+
+    fRooTrackerOutputTree = new TTree("fRooTrackerOutputTree","Event Vertex Truth Array");
+    fRooTrackerOutputTree->Branch("NVtx",&fNVtx,"NVtx/I");
+    fRooTrackerOutputTree->Branch("NRooTrackerVtx","TClonesArray", &fVertices);
+    fNVtx = 0;
+
+    tempVtx = new NRooTrackerVtx();
+}
+
+void WCSimPrimaryGeneratorAction::OpenNeutFile(G4String fileName)
+{
+    if (fInputNeutFile) fInputNeutFile->Delete();
+
+    fInputNeutFile = TFile::Open(fileName.data());
+    if (!fInputNeutFile){ 
+        G4cout << "Cannot open: " << fileName << G4endl; 
+        exit(1);
+    }
+
+    fRooTrackerTree = (TTree*) fInputNeutFile->Get("nRooTracker");
+    if (!fRooTrackerTree){
+        G4cout << "File: " << fileName << " does not contain a NEUT nRooTracker tree - please check you intend to process NEUT events" << G4endl;
+        exit(1);
+    }
+    fNEntries=fRooTrackerTree->GetEntries();
+}
+
+void WCSimPrimaryGeneratorAction::SetupBranchAddresses(NRooTrackerVtx* nrootrackervtx){
+
+    // Set up branch address for rooTrackerVertex tree in nuPRISM files
+    fRooTrackerTree->SetBranchAddress("EvtCode",        &(nrootrackervtx->EvtCode) );
+    fRooTrackerTree->SetBranchAddress("EvtNum",         &(nrootrackervtx->EvtNum) );
+    fRooTrackerTree->SetBranchAddress("EvtXSec",        &(nrootrackervtx->EvtXSec) );
+    fRooTrackerTree->SetBranchAddress("EvtDXSec",       &(nrootrackervtx->EvtDXSec) );
+    fRooTrackerTree->SetBranchAddress("EvtWght",        &(nrootrackervtx->EvtWght) );
+    fRooTrackerTree->SetBranchAddress("EvtProb",        &(nrootrackervtx->EvtProb) );
+    fRooTrackerTree->SetBranchAddress("EvtVtx",          (nrootrackervtx->EvtVtx) );
+    fRooTrackerTree->SetBranchAddress("StdHepN",        &(nrootrackervtx->StdHepN) );
+    fRooTrackerTree->SetBranchAddress("StdHepPdg",       (nrootrackervtx->StdHepPdg) );
+    fRooTrackerTree->SetBranchAddress("StdHepStatus",   &(nrootrackervtx->StdHepStatus) );
+    fRooTrackerTree->SetBranchAddress("StdHepX4",        (nrootrackervtx->StdHepX4) );
+    fRooTrackerTree->SetBranchAddress("StdHepP4",        (nrootrackervtx->StdHepP4) );
+    fRooTrackerTree->SetBranchAddress("StdHepPolz",      (nrootrackervtx->StdHepPolz) );
+    fRooTrackerTree->SetBranchAddress("StdHepFd",        (nrootrackervtx->StdHepFd) );
+    fRooTrackerTree->SetBranchAddress("StdHepLd",        (nrootrackervtx->StdHepLd) );
+    fRooTrackerTree->SetBranchAddress("StdHepFm",        (nrootrackervtx->StdHepFm) );
+    fRooTrackerTree->SetBranchAddress("StdHepLm",        (nrootrackervtx->StdHepLm) );
+
+    // NEUT > v5.0.7 && MCP > 1 (>10a)
+    fRooTrackerTree->SetBranchAddress("NEnvc",          &(nrootrackervtx->NEnvc)    );
+    fRooTrackerTree->SetBranchAddress("NEipvc",          (nrootrackervtx->NEipvc)   );
+    fRooTrackerTree->SetBranchAddress("NEpvc",           (nrootrackervtx->NEpvc)    );
+    fRooTrackerTree->SetBranchAddress("NEiorgvc",        (nrootrackervtx->NEiorgvc) );
+    fRooTrackerTree->SetBranchAddress("NEiflgvc",        (nrootrackervtx->NEiflgvc) );
+    fRooTrackerTree->SetBranchAddress("NEicrnvc",        (nrootrackervtx->NEicrnvc) );
+
+    fRooTrackerTree->SetBranchAddress("NEnvert",        &(nrootrackervtx->NEnvert)  );
+    fRooTrackerTree->SetBranchAddress("NEposvert",       (nrootrackervtx->NEposvert) );
+    fRooTrackerTree->SetBranchAddress("NEiflgvert",      (nrootrackervtx->NEiflgvert) );
+    fRooTrackerTree->SetBranchAddress("NEnvcvert",      &(nrootrackervtx->NEnvcvert) );
+    fRooTrackerTree->SetBranchAddress("NEdirvert",       (nrootrackervtx->NEdirvert) );
+    fRooTrackerTree->SetBranchAddress("NEabspvert",      (nrootrackervtx->NEabspvert) );
+    fRooTrackerTree->SetBranchAddress("NEabstpvert",     (nrootrackervtx->NEabstpvert) );
+    fRooTrackerTree->SetBranchAddress("NEipvert",        (nrootrackervtx->NEipvert)  );
+    fRooTrackerTree->SetBranchAddress("NEiverti",        (nrootrackervtx->NEiverti)  );
+    fRooTrackerTree->SetBranchAddress("NEivertf",        (nrootrackervtx->NEivertf)  );
+    // end NEUT > v5.0.7 && MCP > 1 (>10a)
+
+    // NEUT > v5.1.2 && MCP >= 5
+    fRooTrackerTree->SetBranchAddress("NEcrsx",          &(nrootrackervtx->NEcrsx)    );
+    fRooTrackerTree->SetBranchAddress("NEcrsy",          &(nrootrackervtx->NEcrsy)    );
+    fRooTrackerTree->SetBranchAddress("NEcrsz",          &(nrootrackervtx->NEcrsz)    );
+    fRooTrackerTree->SetBranchAddress("NEcrsphi",        &(nrootrackervtx->NEcrsphi)    );
+
 }
 

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -66,12 +66,12 @@ WCSimPrimaryGeneratorAction::WCSimPrimaryGeneratorAction(
     messenger = new WCSimPrimaryGeneratorMessenger(this);
 
     useMulineEvt = true;
-    useNeutEvt = false;
+    useRootrackerEvt = false;
     useNormalEvt = false;
     useLaserEvt = false;
 
     fEvNum = 0;
-    fInputNeutFile = NULL;
+    fInputRootrackerFile = NULL;
     fNEntries = 0;
 }
 
@@ -85,7 +85,7 @@ WCSimPrimaryGeneratorAction::~WCSimPrimaryGeneratorAction()
     }
     inputFile.close();
 
-    if(useNeutEvt) delete fRooTrackerTree;
+    if(useRootrackerEvt) delete fRooTrackerTree;
 
     delete particleGun;
     delete MyGPS;   //T. Akiri: Delete the GPS variable
@@ -223,11 +223,11 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
         }
     }
 
-    else if (useNeutEvt)
+    else if (useRootrackerEvt)
     { 
-        if ( !fInputNeutFile->IsOpen() )
+        if ( !fInputRootrackerFile->IsOpen() )
         {
-            G4cout << "Set a NEUT vector file using the command /mygen/vecfile name"
+            G4cout << "Set a Rootracker vector file using the command /mygen/vecfile name"
                 << G4endl;
             return;
         }
@@ -246,9 +246,9 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
         }
 
         //Position in WCSim coordinates
-        xPos = fTmpNeutVtx->EvtVtx[0];
-        yPos = fTmpNeutVtx->EvtVtx[1];
-        zPos = fTmpNeutVtx->EvtVtx[2];
+        xPos = fTmpRootrackerVtx->EvtVtx[0];
+        yPos = fTmpRootrackerVtx->EvtVtx[1];
+        zPos = fTmpRootrackerVtx->EvtVtx[2];
 
         //Check if event is outside detector; skip to next event if so; keep
         //loading events until one is found within the detector or there are
@@ -266,9 +266,9 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
                 return; 
             }
             //Convert coordinates
-            xPos = fTmpNeutVtx->EvtVtx[0]; 
-            yPos = fTmpNeutVtx->EvtVtx[1]; 
-            zPos = fTmpNeutVtx->EvtVtx[2];
+            xPos = fTmpRootrackerVtx->EvtVtx[0]; 
+            yPos = fTmpRootrackerVtx->EvtVtx[1]; 
+            zPos = fTmpRootrackerVtx->EvtVtx[2];
         }
 
         //Generate particles
@@ -276,18 +276,18 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
         //i = 1 is the target nucleus
         //i = 2 is the target nucleon
         //i > 2 are the outgoing particles
-        for (int i = 3; i < fTmpNeutVtx->StdHepN; i++){
+        for (int i = 3; i < fTmpRootrackerVtx->StdHepN; i++){
 
-            xDir=fTmpNeutVtx->StdHepP4[i][0];
-            yDir=fTmpNeutVtx->StdHepP4[i][1];
-            zDir=fTmpNeutVtx->StdHepP4[i][2];
+            xDir=fTmpRootrackerVtx->StdHepP4[i][0];
+            yDir=fTmpRootrackerVtx->StdHepP4[i][1];
+            zDir=fTmpRootrackerVtx->StdHepP4[i][2];
 
             double momentum=sqrt(pow(xDir,2)+pow(yDir,2)+pow(zDir,2))*GeV;
 
             G4ThreeVector vtx = G4ThreeVector(xPos, yPos, zPos);
             G4ThreeVector dir = G4ThreeVector(xDir, yDir, zDir);
 
-            particleGun->SetParticleDefinition(particleTable->FindParticle(fTmpNeutVtx->StdHepPdgTemp[i]));
+            particleGun->SetParticleDefinition(particleTable->FindParticle(fTmpRootrackerVtx->StdHepPdgTemp[i]));
             particleGun->SetParticleMomentum(momentum);
             particleGun->SetParticlePosition(vtx);
             particleGun->SetParticleMomentumDirection(dir);
@@ -371,25 +371,25 @@ vector<string> tokenize( string separators, string input )
     return tokens;
 }
 
-void WCSimPrimaryGeneratorAction::OpenNeutFile(G4String fileName)
+void WCSimPrimaryGeneratorAction::OpenRootrackerFile(G4String fileName)
 {
-    if (fInputNeutFile) fInputNeutFile->Delete();
+    if (fInputRootrackerFile) fInputRootrackerFile->Delete();
 
-    fInputNeutFile = TFile::Open(fileName.data());
-    if (!fInputNeutFile){ 
+    fInputRootrackerFile = TFile::Open(fileName.data());
+    if (!fInputRootrackerFile){ 
         G4cout << "Cannot open: " << fileName << G4endl; 
         exit(1);
     }
 
-    fRooTrackerTree = (TTree*) fInputNeutFile->Get("nRooTracker");
+    fRooTrackerTree = (TTree*) fInputRootrackerFile->Get("nRooTracker");
     if (!fRooTrackerTree){
-        G4cout << "File: " << fileName << " does not contain a NEUT nRooTracker tree - please check you intend to process NEUT events" << G4endl;
+        G4cout << "File: " << fileName << " does not contain a Rootracker nRooTracker tree - please check you intend to process Rootracker events" << G4endl;
         exit(1);
     }
     fNEntries=fRooTrackerTree->GetEntries();
 
-    fTmpNeutVtx = new NRooTrackerVtx();
-    SetupBranchAddresses(fTmpNeutVtx); //link fTmpNeutVtx and current input file
+    fTmpRootrackerVtx = new NRooTrackerVtx();
+    SetupBranchAddresses(fTmpRootrackerVtx); //link fTmpRootrackerVtx and current input file
 }
 
 void WCSimPrimaryGeneratorAction::SetupBranchAddresses(NRooTrackerVtx* nrootrackervtx){
@@ -431,7 +431,7 @@ void WCSimPrimaryGeneratorAction::SetupBranchAddresses(NRooTrackerVtx* nrootrack
     fRooTrackerTree->SetBranchAddress("NEipvert",        (nrootrackervtx->NEipvertTemp)  );
     fRooTrackerTree->SetBranchAddress("NEiverti",        (nrootrackervtx->NEivertiTemp)  );
     fRooTrackerTree->SetBranchAddress("NEivertf",        (nrootrackervtx->NEivertfTemp)  );
-    // end NEUT > v5.0.7 && MCP > 1 (>10a)
+    // end Rootracker > v5.0.7 && MCP > 1 (>10a)
 
     // NEUT > v5.1.2 && MCP >= 5
     fRooTrackerTree->SetBranchAddress("NEcrsx",          &(nrootrackervtx->NEcrsx)    );
@@ -440,7 +440,7 @@ void WCSimPrimaryGeneratorAction::SetupBranchAddresses(NRooTrackerVtx* nrootrack
     fRooTrackerTree->SetBranchAddress("NEcrsphi",        &(nrootrackervtx->NEcrsphi)    );
 
 }
-void WCSimPrimaryGeneratorAction::CopyNeutVertex(NRooTrackerVtx* nrootrackervtx){
-    nrootrackervtx->Copy(fTmpNeutVtx);
+void WCSimPrimaryGeneratorAction::CopyRootrackerVertex(NRooTrackerVtx* nrootrackervtx){
+    nrootrackervtx->Copy(fTmpRootrackerVtx);
     nrootrackervtx->TruthVertexID = -999;
 }

--- a/src/WCSimPrimaryGeneratorMessenger.cc
+++ b/src/WCSimPrimaryGeneratorMessenger.cc
@@ -27,6 +27,8 @@ WCSimPrimaryGeneratorMessenger::WCSimPrimaryGeneratorMessenger(WCSimPrimaryGener
   fileNameCmd->SetParameterName("fileName",true);
   fileNameCmd->SetDefaultValue("inputvectorfile");
 
+  genSet = false;
+
 }
 
 WCSimPrimaryGeneratorMessenger::~WCSimPrimaryGeneratorMessenger()
@@ -74,7 +76,6 @@ void WCSimPrimaryGeneratorMessenger::SetNewValue(G4UIcommand * command,G4String 
   {
     if(genSet){
         if(myAction->IsUsingNeutEvtGenerator()){
-            myAction->InitialiseNeutObjects(newValue);
             myAction->OpenNeutFile(newValue);
         }
         else{

--- a/src/WCSimPrimaryGeneratorMessenger.cc
+++ b/src/WCSimPrimaryGeneratorMessenger.cc
@@ -13,13 +13,13 @@ WCSimPrimaryGeneratorMessenger::WCSimPrimaryGeneratorMessenger(WCSimPrimaryGener
   genCmd = new G4UIcmdWithAString("/mygen/generator",this);
   genCmd->SetGuidance("Select primary generator.");
   //T. Akiri: Addition of laser
-  //M. Scott: Addition of NEUT input format
-  genCmd->SetGuidance(" Available generators : muline, normal, laser, neut");
+  //M. Scott: Addition of Rootracker input format
+  genCmd->SetGuidance(" Available generators : muline, normal, laser, rootracker");
   genCmd->SetParameterName("generator",true);
   genCmd->SetDefaultValue("muline");
   //T. Akiri: Addition of laser
-  //M. Scott: Addition of NEUT input format
-  genCmd->SetCandidates("muline normal laser neut");
+  //M. Scott: Addition of Rootracker input format
+  genCmd->SetCandidates("muline normal laser rootracker");
 
   fileNameCmd = new G4UIcmdWithAString("/mygen/vecfile",this);
   fileNameCmd->SetGuidance("Select the file of vectors.");
@@ -45,28 +45,28 @@ void WCSimPrimaryGeneratorMessenger::SetNewValue(G4UIcommand * command,G4String 
     if (newValue == "muline")
     {
       myAction->SetMulineEvtGenerator(true);
-      myAction->SetNeutEvtGenerator(false);
+      myAction->SetRootrackerEvtGenerator(false);
       myAction->SetNormalEvtGenerator(false);
       myAction->SetLaserEvtGenerator(false);
     }
     else if ( newValue == "normal")
     {
       myAction->SetMulineEvtGenerator(false);
-      myAction->SetNeutEvtGenerator(false);
+      myAction->SetRootrackerEvtGenerator(false);
       myAction->SetNormalEvtGenerator(true);
       myAction->SetLaserEvtGenerator(false);
     }
     else if ( newValue == "laser")   //T. Akiri: Addition of laser
     {
       myAction->SetMulineEvtGenerator(false);
-      myAction->SetNeutEvtGenerator(false);
+      myAction->SetRootrackerEvtGenerator(false);
       myAction->SetNormalEvtGenerator(false);
       myAction->SetLaserEvtGenerator(true);
     }
-    else if ( newValue == "neut")   //M. Scott: Addition of NEUT events
+    else if ( newValue == "rootracker")   //M. Scott: Addition of Rootracker events
     {
       myAction->SetMulineEvtGenerator(false);
-      myAction->SetNeutEvtGenerator(true);
+      myAction->SetRootrackerEvtGenerator(true);
       myAction->SetNormalEvtGenerator(false);
       myAction->SetLaserEvtGenerator(false);
     }
@@ -75,8 +75,8 @@ void WCSimPrimaryGeneratorMessenger::SetNewValue(G4UIcommand * command,G4String 
   if( command == fileNameCmd )
   {
     if(genSet){
-        if(myAction->IsUsingNeutEvtGenerator()){
-            myAction->OpenNeutFile(newValue);
+        if(myAction->IsUsingRootrackerEvtGenerator()){
+            myAction->OpenRootrackerFile(newValue);
         }
         else{
             myAction->OpenVectorFile(newValue);
@@ -84,7 +84,7 @@ void WCSimPrimaryGeneratorMessenger::SetNewValue(G4UIcommand * command,G4String 
         G4cout << "Input vector file set to " << newValue << G4endl;
     }
     else{
-        G4cout << "Generator has not been set, guessing input vector file is NOT in the NEUT format - this will crash if you are using a NEUT input file" << G4endl;
+        G4cout << "Generator has not been set, guessing input vector file is NOT in the Rootracker format - this will crash if you are using a Rootracker input file" << G4endl;
         G4cout << "Please put the '/mygen/generator' command above the '/mygen/vecfile' command in the mac file." << G4endl;
     }
   }
@@ -102,8 +102,8 @@ G4String WCSimPrimaryGeneratorMessenger::GetCurrentValue(G4UIcommand* command)
       { cv = "normal"; }
     else if(myAction->IsUsingLaserEvtGenerator())
       { cv = "laser"; }   //T. Akiri: Addition of laser
-    else if(myAction->IsUsingNeutEvtGenerator())
-      { cv = "neut"; }   //M. Scott: Addition of NEUT events
+    else if(myAction->IsUsingRootrackerEvtGenerator())
+      { cv = "rootracker"; }   //M. Scott: Addition of Rootracker events
   }
   
   return cv;

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -33,6 +33,9 @@ WCSimRunAction::WCSimRunAction(WCSimDetectorConstruction* test)
   wcsimdetector = test;
   messenger = new WCSimRunActionMessenger(this);
 
+  // By default do not try and save Neut interaction information
+  SetSaveRooTracker(0);
+
 }
 
 WCSimRunAction::~WCSimRunAction()
@@ -86,6 +89,16 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* aRun)
   TBranch *geoBranch = geoTree->Branch("wcsimrootgeom", "WCSimRootGeom", &wcsimrootgeom, bufsize,0);
 
   FillGeoTree();
+
+  if(GetSaveRooTracker()){
+    //Setup TClonesArray to store NEUT truth info
+    fVertices = new TClonesArray("NRooTrackerVtx", 10);
+    fVertices->Clear();
+    fNVtx = 0;
+    fRooTrackerOutputTree = new TTree("fRooTrackerOutputTree","Event Vertex Truth Array");
+    fRooTrackerOutputTree->Branch("NVtx",&fNVtx,"NVtx/I");
+    fRooTrackerOutputTree->Branch("NRooTrackerVtx","TClonesArray", &fVertices);
+  }      
 }
 
 void WCSimRunAction::EndOfRunAction(const G4Run*)
@@ -187,4 +200,10 @@ void WCSimRunAction::FillGeoTree(){
   geoTree->Fill();
   TFile* hfile = geoTree->GetCurrentFile();
   hfile->Write(); 
+}
+
+NRooTrackerVtx* WCSimRunAction::GetNeutVertex(){
+  NRooTrackerVtx* currNeutVtx = new((*fVertices)[fNVtx])NRooTrackerVtx();
+  fNVtx += 1;
+  return currNeutVtx;
 }

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -102,8 +102,10 @@ void WCSimRunAction::EndOfRunAction(const G4Run*)
 //  G4cout << (float(numberOfTimesCatcherHit)/float(numberOfEventsGenerated))*100.
 //        << "% through-going (hit Catcher)" << G4endl;
 
-  // Close the Root file at the end of the run
 
+
+
+  // Close the Root file at the end of the run
   TFile* hfile = WCSimTree->GetCurrentFile();
   hfile->Close();
 

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -33,7 +33,7 @@ WCSimRunAction::WCSimRunAction(WCSimDetectorConstruction* test)
   wcsimdetector = test;
   messenger = new WCSimRunActionMessenger(this);
 
-  // By default do not try and save Neut interaction information
+  // By default do not try and save Rootracker interaction information
   SetSaveRooTracker(0);
 
 }
@@ -91,7 +91,7 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* aRun)
   FillGeoTree();
 
   if(GetSaveRooTracker()){
-    //Setup TClonesArray to store NEUT truth info
+    //Setup TClonesArray to store Rootracker truth info
     fVertices = new TClonesArray("NRooTrackerVtx", 10);
     fVertices->Clear();
     fNVtx = 0;
@@ -202,8 +202,8 @@ void WCSimRunAction::FillGeoTree(){
   hfile->Write(); 
 }
 
-NRooTrackerVtx* WCSimRunAction::GetNeutVertex(){
-  NRooTrackerVtx* currNeutVtx = new((*fVertices)[fNVtx])NRooTrackerVtx();
+NRooTrackerVtx* WCSimRunAction::GetRootrackerVertex(){
+  NRooTrackerVtx* currRootrackerVtx = new((*fVertices)[fNVtx])NRooTrackerVtx();
   fNVtx += 1;
-  return currNeutVtx;
+  return currRootrackerVtx;
 }

--- a/src/WCSimRunActionMessenger.cc
+++ b/src/WCSimRunActionMessenger.cc
@@ -5,6 +5,7 @@
 #include "G4UIcommand.hh"
 #include "G4UIparameter.hh"
 #include "G4UIcmdWithAString.hh"
+#include "G4UIcmdWithABool.hh"
 
 WCSimRunActionMessenger::WCSimRunActionMessenger(WCSimRunAction* WCSimRA)
 :WCSimRun(WCSimRA)
@@ -18,11 +19,18 @@ WCSimRunActionMessenger::WCSimRunActionMessenger(WCSimRunAction* WCSimRA)
   RootFile->SetParameterName("RootFileName",true);
   RootFile->SetDefaultValue("wcsim.root");
 
+  RooTracker = new G4UIcmdWithABool("/WCSimIO/SaveRooTracker",this);
+  RooTracker->SetGuidance("Save the input NEUT Rootracker objects to the output file");
+  RooTracker->SetGuidance("Enter a boolean to save or drop the NEUT RooTracker information");
+  RooTracker->SetParameterName("SaveRooTracker",false);
+  RooTracker->SetDefaultValue(false);
+
 }
 
 WCSimRunActionMessenger::~WCSimRunActionMessenger()
 {
   delete RootFile;
+  delete RooTracker;
   delete WCSimIODir;
 }
 
@@ -35,4 +43,11 @@ void WCSimRunActionMessenger::SetNewValue(G4UIcommand* command,G4String newValue
       G4cout << "Output ROOT file set to " << newValue << G4endl;
     }
 
+  if ( command == RooTracker)
+    {
+      WCSimRun->SetSaveRooTracker(RooTracker->GetNewBoolValue(newValue));
+      if(newValue) G4cout << "Saving NEUT RooTracker information to output file"  << G4endl;
+    }
+
 }
+


### PR DESCRIPTION
Add the ability to read NEUT vertices directly in WCSim

Currently this uses the absolute position of the NEUT event (from the EvtVtx array) to place the interaction in WCSim - there are no translations or rotations applied to align coordinate systems, so this addition is not specific to nuPRISM.  nuPRISM will have to adjust the coordinates manually before running WCSim, or make further changes to WCSim to read nuPRISM specific files.

Also, to do this easily I added the NRooTrackerVtx and JNuBeamFlux classes from T2K/ND280 to WCSim.  This may be a problem, since these objects are not public.  The NEUT vector format has not changed for a long time now, so should be stable.