### PR TITLE
Implement variable nuPRISM geometry

### DIFF
--- a/convertNuPRISM.C
+++ b/convertNuPRISM.C
@@ -1,0 +1,7 @@
+{
+gROOT->ProcessLine(".L $WCSIMDIR/libWCSimRoot.so");
+gSystem->AddIncludePath(" -I$WCSIMDIR/include/");
+gROOT->ProcessLine(".L nuPRISMconvert.cc+");
+
+}
+

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -70,7 +70,7 @@ public:
   void DUSEL_200kton_12inch_HQE_10perCent();
   void DUSEL_200kton_12inch_HQE_14perCent();
 
-  void SetNuPrismGeometry(G4String PMTType, G4double PMTCoverage, G4double detectorHeight, G4double detectorDiameter);
+  void SetNuPrismGeometry(G4String PMTType, G4double PMTCoverage, G4double detectorHeight, G4double detectorDiameter, G4double verticalPosition);
   void SetDefaultNuPrismGeometry();
 
 
@@ -145,6 +145,9 @@ public:
 
   void   SetDetectorHeight(G4double height) {WCIDHeight = height;}
   G4double GetWCIDHeight(){ return WCIDHeight; }
+
+  void   SetDetectorVerticalPosition(G4double position) {WCIDVerticalPosition = position;}
+  G4double GetWCIDVerticalPosition(){ return WCIDVerticalPosition; }
 
   void   SetDetectorDiameter(G4double diameter) {WCIDDiameter = diameter;}
   G4double GetWCIDDiameter(){ return WCIDDiameter; }
@@ -269,6 +272,7 @@ private:
   G4double WCBackODLength;
   G4double WCFrontODLength;
   G4double WCIDHeight;
+  G4double WCIDVerticalPosition;
 
   G4double WCBarrelRingRadius;
 

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -66,8 +66,10 @@ public:
   void DUSEL_200kton_10inch_HQE_12perCent();
   void DUSEL_200kton_12inch_HQE_10perCent();
   void DUSEL_200kton_12inch_HQE_14perCent();
+
+  void SetNuPrismGeometry(G4String PMTType, G4double PMTCoverage, G4double detectorHeight, G4double detectorDiameter);
+ 
   void UpdateGeometry();
-  
 
   G4double GetWaterTubeLength()   {return WCLength;}
   G4double GetWaterTubePosition() {return WCPosition;}

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -18,6 +18,9 @@
 // warning : hash_map is not part of the standard
 #include <ext/hash_map>
 
+#include "TFile.h"
+#include "TTree.h"
+#include "TMath.h"
 
 using __gnu_cxx::hash;
 using __gnu_cxx::hashtable;
@@ -68,7 +71,10 @@ public:
   void DUSEL_200kton_12inch_HQE_14perCent();
 
   void SetNuPrismGeometry(G4String PMTType, G4double PMTCoverage, G4double detectorHeight, G4double detectorDiameter);
- 
+  void SetDefaultNuPrismGeometry();
+  void SetInputSettingsFilename(G4String file) {fInputSettingsFilename = file;}
+
+
   void UpdateGeometry();
 
   G4double GetWaterTubeLength()   {return WCLength;}
@@ -94,7 +100,12 @@ public:
   WCSimPMTObject*  GetPMTPointer(){return PMTptr;}
 
   G4ThreeVector GetWCOffset(){return WCOffset;}
-  
+  G4ThreeVector GetWCXRotation(){return WCXRotation;}
+  G4ThreeVector GetWCYRotation(){return WCYRotation;}
+  G4ThreeVector GetWCZRotation(){return WCZRotation;}
+
+  G4ThreeVector GetTranslationFromSettings();
+
   // Related to the WC tube IDs
   static G4int GetTubeID(std::string tubeTag){return tubeLocationMap[tubeTag];}
   static G4Transform3D GetTubeTransform(int tubeNo){return tubeIDMap[tubeNo];}
@@ -127,10 +138,20 @@ public:
   void   SetIsNuPrism(G4bool choice) {isNuPrism = choice;}
   G4bool GetIsNuPrism() {return isNuPrism;}
 
+  void   SetPMTType(G4String type) {WCPMTType = type;}
+  G4String GetPMTType() {return WCPMTType;}
+
+  void   SetPMTCoverage(G4double cover) {WCPMTCoverage = cover;}
+  G4double GetPMTCoverage() {return WCPMTCoverage;}
+
   std::vector<WCSimPmtInfo*>* Get_Pmts() {return &fpmts;}
 
-  G4double GetWCIDDiameter(){ return WCIDDiameter; }
+  void   SetDetectorHeight(G4double height) {WCIDHeight = height;}
   G4double GetWCIDHeight(){ return WCIDHeight; }
+
+  void   SetDetectorDiameter(G4double diameter) {WCIDDiameter = diameter;}
+  G4double GetWCIDDiameter(){ return WCIDDiameter; }
+
 
 private:
 
@@ -293,6 +314,10 @@ private:
 
   // Add bool to indicate whether we load nuPRISM geometry  
   G4bool isNuPrism;
+  G4String WCPMTType;
+  G4double WCPMTCoverage;
+  G4String fInputSettingsFilename;
+  TTree* fSettingsTree;
 
   // *** Begin HyperK Geometry ***
 
@@ -368,6 +393,9 @@ private:
   G4double WCCylInfo[3];    // Info for the geometry tree: radius & length or mail box, length, width and depth
   G4double WCPMTSize;       // Info for the geometry tree: pmt size
   G4ThreeVector WCOffset;   // Info for the geometry tree: WC center offset
+  G4ThreeVector WCXRotation;   // Info for the geometry tree: WC detector local X axis in the global coordinate system 
+  G4ThreeVector WCYRotation;   // Info for the geometry tree: WC detector local Y axis in the global coordinate system 
+  G4ThreeVector WCZRotation;   // Info for the geometry tree: WC detector local Z axis in the global coordinate system 
 
   // Tube map information
 

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -72,7 +72,6 @@ public:
 
   void SetNuPrismGeometry(G4String PMTType, G4double PMTCoverage, G4double detectorHeight, G4double detectorDiameter);
   void SetDefaultNuPrismGeometry();
-  void SetInputSettingsFilename(G4String file) {fInputSettingsFilename = file;}
 
 
   void UpdateGeometry();
@@ -103,8 +102,6 @@ public:
   G4ThreeVector GetWCXRotation(){return WCXRotation;}
   G4ThreeVector GetWCYRotation(){return WCYRotation;}
   G4ThreeVector GetWCZRotation(){return WCZRotation;}
-
-  G4ThreeVector GetTranslationFromSettings();
 
   // Related to the WC tube IDs
   static G4int GetTubeID(std::string tubeTag){return tubeLocationMap[tubeTag];}
@@ -316,8 +313,6 @@ private:
   G4bool isNuPrism;
   G4String WCPMTType;
   G4double WCPMTCoverage;
-  G4String fInputSettingsFilename;
-  TTree* fSettingsTree;
 
   // *** Begin HyperK Geometry ***
 

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -121,6 +121,10 @@ public:
 
   // *** End HyperK Geometry ***
 
+  // Set if nuPRISM
+  void   SetIsNuPrism(G4bool choice) {isNuPrism = choice;}
+  G4bool GetIsNuPrism() {return isNuPrism;}
+
   std::vector<WCSimPmtInfo*>* Get_Pmts() {return &fpmts;}
 
   G4double GetWCIDDiameter(){ return WCIDDiameter; }
@@ -284,6 +288,9 @@ private:
 
   // amb79: to universally make changes in structure and geometry
   bool isUpright;
+
+  // Add bool to indicate whether we load nuPRISM geometry  
+  G4bool isNuPrism;
 
   // *** Begin HyperK Geometry ***
 

--- a/include/WCSimDetectorMessenger.hh
+++ b/include/WCSimDetectorMessenger.hh
@@ -48,6 +48,7 @@ class WCSimDetectorMessenger: public G4UImessenger
   G4UIcmdWithAString* SetPMTType;
   G4UIcmdWithAString* SetPMTCoverage;
   G4UIcmdWithADoubleAndUnit* SetDetectorHeight;
+  G4UIcmdWithADoubleAndUnit* SetDetectorVerticalPosition;
   G4UIcmdWithADoubleAndUnit* SetDetectorDiameter;
 
 };

--- a/include/WCSimDetectorMessenger.hh
+++ b/include/WCSimDetectorMessenger.hh
@@ -43,6 +43,14 @@ class WCSimDetectorMessenger: public G4UImessenger
   G4UIcmdWithAString* distortionCmd;
   G4UIcmdWithoutParameter* WCConstruct;
 
+  //nuPRISM commands
+  G4UIcmdWithoutParameter* UpdateNuPrism;
+  G4UIcmdWithAString* SettingsFile;
+  G4UIcmdWithAString* SetPMTType;
+  G4UIcmdWithAString* SetPMTCoverage;
+  G4UIcmdWithADoubleAndUnit* SetDetectorHeight;
+  G4UIcmdWithADoubleAndUnit* SetDetectorDiameter;
+
 };
 
 #endif

--- a/include/WCSimDetectorMessenger.hh
+++ b/include/WCSimDetectorMessenger.hh
@@ -45,7 +45,6 @@ class WCSimDetectorMessenger: public G4UImessenger
 
   //nuPRISM commands
   G4UIcmdWithoutParameter* UpdateNuPrism;
-  G4UIcmdWithAString* SettingsFile;
   G4UIcmdWithAString* SetPMTType;
   G4UIcmdWithAString* SetPMTCoverage;
   G4UIcmdWithADoubleAndUnit* SetDetectorHeight;

--- a/include/WCSimPrimaryGeneratorAction.hh
+++ b/include/WCSimPrimaryGeneratorAction.hh
@@ -100,7 +100,11 @@ class WCSimPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
         // Pointers to Rootracker vertex objects
         // Temporary vertex that is saved if desired, according to WCSimIO macro option
         TTree* fRooTrackerTree;
+        TTree* fSettingsTree;
         NRooTrackerVtx* fTmpRootrackerVtx;
+        double fNuPrismRadius;
+        double fNuBeamAng;
+        double fNuPlanePos[3];
 
     public:
 

--- a/include/WCSimPrimaryGeneratorAction.hh
+++ b/include/WCSimPrimaryGeneratorAction.hh
@@ -104,6 +104,8 @@ class WCSimPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
 
     public:
 
+        inline TFile* GetInputRootrackerFile(){ return fInputRootrackerFile;}
+
         inline void SetMulineEvtGenerator(G4bool choice) { useMulineEvt = choice; }
         inline G4bool IsUsingMulineEvtGenerator() { return useMulineEvt; }
 

--- a/include/WCSimPrimaryGeneratorAction.hh
+++ b/include/WCSimPrimaryGeneratorAction.hh
@@ -102,9 +102,9 @@ class WCSimPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
         TTree* fRooTrackerTree;
         TTree* fSettingsTree;
         NRooTrackerVtx* fTmpRootrackerVtx;
-        double fNuPrismRadius;
-        double fNuBeamAng;
-        double fNuPlanePos[3];
+        float fNuPrismRadius;
+        float fNuBeamAng;
+        float fNuPlanePos[3];
 
     public:
 

--- a/include/WCSimRootGeom.hh
+++ b/include/WCSimRootGeom.hh
@@ -59,7 +59,11 @@ private:
   Float_t                fWCPMTRadius; // Radius of PMT
   Int_t                  fWCNumPMT;   // Number of PMTs
   Float_t                fWCOffset[3]; // Offset of barrel center in global coords
-  Int_t                  fOrientation; //Orientation o detector, 0 is 2km horizontal, 1 is Upright
+  Float_t                fWCXRotation[3]; // Barrel local axis in global coords
+  Float_t                fWCYRotation[3]; // Barrel local axis in global coords
+  Float_t                fWCZRotation[3]; // Barrel local axis in global coords
+
+   Int_t                  fOrientation; //Orientation o detector, 0 is 2km horizontal, 1 is Upright
 
   // Could make a TClonesArray of PMTs but let's keep it simple
   //   since the arrays just won't be that large
@@ -82,6 +86,17 @@ public:
   void  SetWCPMTRadius(Float_t f) {fWCPMTRadius = f;}
   void  SetWCOffset(Float_t x, Float_t y, Float_t z) 
            {fWCOffset[0]=x; fWCOffset[1]=y; fWCOffset[2] = z;}
+  void  SetWCXRotation(Float_t x, Float_t y, Float_t z) 
+           {fWCXRotation[0]=x; fWCXRotation[1]=y; fWCXRotation[2] = z;}
+  void  SetWCYRotation(Float_t x, Float_t y, Float_t z) 
+           {fWCYRotation[0]=x; fWCYRotation[1]=y; fWCYRotation[2] = z;}
+  void  SetWCZRotation(Float_t x, Float_t y, Float_t z) 
+           {fWCZRotation[0]=x; fWCZRotation[1]=y; fWCZRotation[2] = z;}
+
+
+
+
+
   void  SetPMT(Int_t i, Int_t tubeno, Int_t cyl_loc, Float_t rot[3], Float_t pos[3], bool expand=true);
   void  SetOrientation(Int_t o) {fOrientation = o;}
 
@@ -94,6 +109,11 @@ public:
   Int_t GetWCNumPMT() const {return fWCNumPMT;}
   Float_t GetWCPMTRadius() const {return fWCPMTRadius;}
   Float_t GetWCOffset(Int_t i) const {return (i<3) ? fWCOffset[i] : 0.;}
+  Float_t GetWCXRotation(Int_t i) const {return (i<3) ? fWCXRotation[i] : 0.;}
+  Float_t GetWCYRotation(Int_t i) const {return (i<3) ? fWCYRotation[i] : 0.;}
+  Float_t GetWCZRotation(Int_t i) const {return (i<3) ? fWCZRotation[i] : 0.;}
+
+   
   Int_t GetOrientation() { return fOrientation; }
   //WCSimRootPMT GetPMT(Int_t i){return *(new WCSimRootPMT());}
   WCSimRootPMT GetPMT(Int_t i){return *(WCSimRootPMT*)(*fPMTArray)[i];}

--- a/include/WCSimRunAction.hh
+++ b/include/WCSimRunAction.hh
@@ -51,6 +51,7 @@ public:
 
   NRooTrackerVtx* GetRootrackerVertex();
   void FillRootrackerVertexTree() { fRooTrackerOutputTree->Fill();}
+  void FillSettingsTree() { fSettingsOutputTree->Fill();}
   void ClearRootrackerVertexArray() { 
       fVertices->Clear(); 
       fNVtx = 0;
@@ -75,6 +76,7 @@ private:
   TTree* fRooTrackerOutputTree;
   int fNVtx;
   bool SaveRooTracker;
+  TTree* fSettingsOutputTree;
 
   WCSimRunActionMessenger* messenger;
   int ntuples;  // 1 for ntuples to be written

--- a/novis.mac
+++ b/novis.mac
@@ -39,12 +39,11 @@
 
 /WCSim/WCgeom nuPRISM
 
-/WCSim/nuPRISM/SetPMTType PMT20inch
-/WCSim/nuPRISM/SettingsFile /neut/data21/mscott/nuPRISM_Software/genev_320a_1km_nd2_9xx_test.root
-/WCSim/nuPRISM/SetPMTPercentCoverage 40
-/WCSim/nuPRISM/SetDetectorHeight 10. m
-/WCSim/nuPRISM/SetDetectorDiameter 6. m
-/WCSim/nuPRISM/Update
+#/WCSim/nuPRISM/SetPMTType PMT8inch
+#/WCSim/nuPRISM/SetPMTPercentCoverage 40
+#/WCSim/nuPRISM/SetDetectorHeight 30. m
+#/WCSim/nuPRISM/SetDetectorDiameter 12. m
+#/WCSim/nuPRISM/Update
 /WCSim/Construct
 
 
@@ -93,7 +92,7 @@
 #/gun/position 0 0 0  
 
 ## change the name of the output root file, default = wcsim.root
-/WCSimIO/RootFile wcsim_TestNewNeut.root
+/WCSimIO/RootFile wcsim_TestNEUT.root
 
 ## Boolean to select whether to save the NEUT RooTracker vertices in the output file, provided you used
 ## a NEUT vector file as input

--- a/novis.mac
+++ b/novis.mac
@@ -39,7 +39,7 @@
 
 /WCSim/WCgeom nuPRISM
 
-/WCSim/nuPRISM/SetPMTType PMT8inch
+/WCSim/nuPRISM/SetPMTType PMT20inch
 /WCSim/nuPRISM/SettingsFile /neut/data21/mscott/nuPRISM_Software/genev_320a_1km_nd2_9xx_test.root
 /WCSim/nuPRISM/SetPMTPercentCoverage 40
 /WCSim/nuPRISM/SetDetectorHeight 10. m
@@ -63,14 +63,14 @@
 #/WCSim/PMTQEMethod     SensitiveDetector_Only
 
 # command to choose save or not save the pi0 info 07/03/10 (XQ)
-/WCSim/SavePi0 false
+/WCSim/SavePi0 true
 
 ## select the input nuance-formatted vector file
 ## you can of course use your own
 # Or you can use the G4 Particle Gun below
 # Or a NEUT vector file
-/mygen/generator normal
-#/mygen/vecfile genev_320a_1km_nd2_9xx_test.root
+/mygen/generator rootracker
+/mygen/vecfile genev_320a_1km_nd3_9xx_30818.root
 #/mygen/vecfile h2o.2km.001-009x3_G4.kin
 #/mygen/vecfile mu+.out
 
@@ -86,18 +86,18 @@
 /DarkRate/SetConvert 1.367
 #/DarkRate/SetConvert 1.120 #For HPDs
 
-/gun/particle mu-
+#/gun/particle mu- 
 #/gun/particle pi0
-/gun/energy 500 MeV
-/gun/direction 0 0 1 
-/gun/position 0 -3800 100000  
+#/gun/energy 500 MeV
+#/gun/direction 0 0 1 
+#/gun/position 0 0 0  
 
 ## change the name of the output root file, default = wcsim.root
-/WCSimIO/RootFile wcsim.root
+/WCSimIO/RootFile wcsim_TestNewNeut.root
 
 ## Boolean to select whether to save the NEUT RooTracker vertices in the output file, provided you used
 ## a NEUT vector file as input
-#/WCSimIO/SaveRooTracker 1
+/WCSimIO/SaveRooTracker 1
 
-/run/beamOn 1
+/run/beamOn 10
 #exit

--- a/novis.mac
+++ b/novis.mac
@@ -39,11 +39,16 @@
 
 /WCSim/WCgeom nuPRISM
 
-#/WCSim/nuPRISM/SetPMTType PMT8inch
-#/WCSim/nuPRISM/SetPMTPercentCoverage 40
-#/WCSim/nuPRISM/SetDetectorHeight 30. m
-#/WCSim/nuPRISM/SetDetectorDiameter 12. m
-#/WCSim/nuPRISM/Update
+#Select which PMT to use
+/WCSim/nuPRISM/SetPMTType PMT8inch
+/WCSim/nuPRISM/SetPMTPercentCoverage 20
+#Set height of nuPRISM inner detector
+/WCSim/nuPRISM/SetDetectorHeight 10. m
+#Set vertical position of inner detector, in beam coordinates
+/WCSim/nuPRISM/SetDetectorVerticalPosition -10. m
+#Set diameter of inner detector
+/WCSim/nuPRISM/SetDetectorDiameter 6. m
+/WCSim/nuPRISM/Update
 /WCSim/Construct
 
 
@@ -69,7 +74,7 @@
 # Or you can use the G4 Particle Gun below
 # Or a NEUT vector file
 /mygen/generator rootracker
-/mygen/vecfile genev_320a_1km_nd3_9xx_30818.root
+/mygen/vecfile ../genev_320a_1km_nd3_9xx_30818.root
 #/mygen/vecfile h2o.2km.001-009x3_G4.kin
 #/mygen/vecfile mu+.out
 
@@ -92,7 +97,7 @@
 #/gun/position 0 0 0  
 
 ## change the name of the output root file, default = wcsim.root
-/WCSimIO/RootFile wcsim_TestNEUT.root
+/WCSimIO/RootFile wcsim_output.root
 
 ## Boolean to select whether to save the NEUT RooTracker vertices in the output file, provided you used
 ## a NEUT vector file as input

--- a/novis.mac
+++ b/novis.mac
@@ -36,7 +36,17 @@
 #/WCSim/WCgeom DUSEL_200kton_10inch_HQE_12perCent
 #/WCSim/WCgeom DUSEL_200kton_12inch_HQE_10perCent
 #/WCSim/WCgeom DUSEL_200kton_12inch_HQE_14perCent
-#/WCSim/Construct
+
+/WCSim/WCgeom nuPRISM
+
+/WCSim/nuPRISM/SetPMTType PMT8inch
+/WCSim/nuPRISM/SettingsFile /neut/data21/mscott/nuPRISM_Software/genev_320a_1km_nd2_9xx_test.root
+/WCSim/nuPRISM/SetPMTPercentCoverage 40
+/WCSim/nuPRISM/SetDetectorHeight 10. m
+/WCSim/nuPRISM/SetDetectorDiameter 6. m
+/WCSim/nuPRISM/Update
+/WCSim/Construct
+
 
 #Added for the PMT QE option 08/17/10 (XQ)
 # 1. Stacking only mean when the photon is generated
@@ -76,11 +86,11 @@
 /DarkRate/SetConvert 1.367
 #/DarkRate/SetConvert 1.120 #For HPDs
 
-/gun/particle e-
+/gun/particle mu-
 #/gun/particle pi0
 /gun/energy 500 MeV
-/gun/direction 1 0 0 
-/gun/position 0 0 0  
+/gun/direction 0 0 1 
+/gun/position 0 -3800 100000  
 
 ## change the name of the output root file, default = wcsim.root
 /WCSimIO/RootFile wcsim.root
@@ -89,5 +99,5 @@
 ## a NEUT vector file as input
 #/WCSimIO/SaveRooTracker 1
 
-/run/beamOn 10
+/run/beamOn 1
 #exit

--- a/nuPRISMconvert.cc
+++ b/nuPRISMconvert.cc
@@ -1,0 +1,405 @@
+#include <iostream>
+#include <TH1F.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <TFile.h>
+#include <TTree.h>
+#include <TKey.h>
+#include <WCSimRootEvent.hh>
+
+/* converts position and direction branches in the fiTQun tree to nuPRISM coordinate system
+ * and copies the rest of the branches into a new fiTQun tree
+ */
+void convertfiTQun(TTree* fiTQun, TTree* fiTQunCv) {
+
+    // copies fiTQun tree to a new tree without any position and direction branches
+    fiTQun->SetBranchStatus("*", 1);
+    fiTQun->SetBranchStatus("fq*pos*",0);
+    fiTQun->SetBranchStatus("fq*dir*",0);
+    fiTQunCv = fiTQun->CloneTree();
+    fiTQun->CopyAddresses(fiTQunCv, kTRUE);
+
+    // sets branches back to be processed
+    fiTQun->SetBranchStatus("fq*pos*",1);
+    fiTQun->SetBranchStatus("fq*dir*",1);
+
+    // initialize position and direction variables and their converted counterparts
+    const Int_t MAX_TEMP = 100;
+    Int_t fqntwnd;
+    Float_t fqtwnd_prftpos[MAX_TEMP][3];    // pre-fitter vertex position
+    Float_t fqtwnd_prftposCv[MAX_TEMP][3];
+    Int_t fqnse;
+    Float_t fq1rpos[MAX_TEMP][7][3];        // 1 ring fit vertex
+    Float_t fq1rposCv[MAX_TEMP][7][3];
+    Float_t fq1rdir[MAX_TEMP][7][3];        // 1 ring fit direction
+    Float_t fq1rdirCv[MAX_TEMP][7][3];
+    Float_t fqpi0pos[2][3];                 // Pi0 fit vertex position
+    Float_t fqpi0posCv[2][3];
+    Float_t fqpi0dir1[2][3];                // Pi0 fit direction of the first photon
+    Float_t fqpi0dir1Cv[2][3];
+    Float_t fqpi0dir2[2][3];                // Pi0 fit direction of the second photon
+    Float_t fqpi0dir2Cv[2][3];
+    Float_t fqpi0dirtot[2][3];              // Pi0 fit direction of the Pi0
+    Float_t fqpi0dirtotCv[2][3];
+    Int_t fqnmrfit;
+    Float_t fqmrpos[MAX_TEMP][6][3];        // Multi-Ring fit vertex position of each ring
+    Float_t fqmrposCv[MAX_TEMP][6][3];
+    Float_t fqmrdir[MAX_TEMP][6][3];        // Multi-Ring fit direction of each ring
+    Float_t fqmrdirCv[MAX_TEMP][6][3];
+    Int_t fqmsnfit;
+    Float_t fqmspos[MAX_TEMP][20][3];       // Multi-Segment Muon fit vertex position of each segment
+    Float_t fqmsposCv[MAX_TEMP][20][3];
+    Float_t fqmsdir[MAX_TEMP][20][3];       // Multi-Segment Muon fit direction of each segment
+    Float_t fqmsdirCv[MAX_TEMP][20][3];
+    Int_t fqtestn1r;
+    Float_t fqtest1rpos[MAX_TEMP][3];       // test 1 ring fit vertex
+    Float_t fqtest1rposCv[MAX_TEMP][3];
+    Float_t fqtest1rdir[MAX_TEMP][3];       // test 1 ring fit directio
+    Float_t fqtest1rdirCv[MAX_TEMP][3];
+    Int_t fqtestnpi0;
+    Float_t fqtestpi0pos[MAX_TEMP][3];      // test Pi0 fit vertex position
+    Float_t fqtestpi0posCv[MAX_TEMP][3];
+    Float_t fqtestpi0dir1[MAX_TEMP][3];     // test Pi0 fit direction of the first photon
+    Float_t fqtestpi0dir1Cv[MAX_TEMP][3];
+    Float_t fqtestpi0dir2[MAX_TEMP][3];     // test Pi0 fit direction of the second photon
+    Float_t fqtestpi0dir2Cv[MAX_TEMP][3];
+    Float_t fqtestpi0dirtot[MAX_TEMP][3];   // test Pi0 fit direction of the Pi0
+    Float_t fqtestpi0dirtotCv[MAX_TEMP][3];
+
+    // initializes branches in fiTQunCv output
+    TBranch *bfqtwnd_prftpos = fiTQunCv->Branch("fqtwnd_prftpos",fqtwnd_prftposCv,"fqtwnd_prftpos[fqntwnd][3]/F");
+    TBranch *bfq1rpos = fiTQunCv->Branch("fq1rpos",fq1rposCv,"fq1rpos[fqnse][7][3]/F");
+    TBranch *bfq1rdir = fiTQunCv->Branch("fq1rdir",fq1rdirCv,"fq1rdir[fqnse][7][3]/F");
+    TBranch *bfqpi0pos = fiTQunCv->Branch("fqpi0pos",fqpi0posCv,"fqpi0pos[2][3]/F");
+    TBranch *bfqpi0dir1 = fiTQunCv->Branch("fqpi0dir1",fqpi0dir1Cv,"fqpi0dir1[2][3]/F");
+    TBranch *bfqpi0dir2 = fiTQunCv->Branch("fqpi0dir2",fqpi0dir2Cv,"fqpi0dir2[2][3]/F");
+    TBranch *bfqpi0dirtot = fiTQunCv->Branch("fqpi0dirtot",fqpi0dirtotCv,"fqpi0dirtot[2][3]/F");
+    TBranch *bfqmrpos = fiTQunCv->Branch("fqmrpos",fqmrposCv,"fqmrpos[fqnmrfit][6][3]/F");
+    TBranch *bfqmrdir = fiTQunCv->Branch("fqmrdir",fqmrdirCv,"fqmrdir[fqnmrfit][6][3]/F");
+    TBranch *bfqmspos = fiTQunCv->Branch("fqmspos",fqmsposCv,"fqmspos[fqmsnfit][20][3]/F");
+    TBranch *bfqmsdir = fiTQunCv->Branch("fqmsdir",fqmsdirCv,"fqmsdir[fqmsnfit][20][3]/F");
+    TBranch *bfqtest1rpos = fiTQunCv->Branch("fqtest1rpos",fqtest1rposCv,"fqtest1rpos[fqtestn1r][3]/F");
+    TBranch *bfqtest1rdir = fiTQunCv->Branch("fqtest1rdir",fqtest1rdirCv,"fqtest1rdir[fqtestn1r][3]/F");
+    TBranch *bfqtestpi0pos = fiTQunCv->Branch("fqtestpi0pos",fqtestpi0posCv,"fqtestpi0pos[fqtestnpi0][3]/F");
+    TBranch *bfqtestpi0dir1 = fiTQunCv->Branch("fqtestpi0dir1",fqtestpi0dir1Cv,"fqtestpi0dir1[fqtestnpi0][3]/F");
+    TBranch *bfqtestpi0dir2 = fiTQunCv->Branch("fqtestpi0dir2",fqtestpi0dir2Cv,"fqtestpi0dir2[fqtestnpi0][3]/F");
+    TBranch *bfqtestpi0dirtot = fiTQunCv->Branch("fqtestpi0dirtot",fqtestpi0dirtotCv,"fqtestpi0dirtot[fqtestnpi0][3]/F");
+    fiTQun->SetBranchAddress("fqntwnd", &fqntwnd);
+    fiTQun->SetBranchAddress("fqtwnd_prftpos", &fqtwnd_prftpos);
+    fiTQun->SetBranchAddress("fqnse", &fqnse);
+    fiTQun->SetBranchAddress("fq1rpos", &fq1rpos);
+    fiTQun->SetBranchAddress("fq1rdir", &fq1rdir);
+    fiTQun->SetBranchAddress("fqpi0pos", &fqpi0pos);
+    fiTQun->SetBranchAddress("fqpi0dir1", &fqpi0dir1);
+    fiTQun->SetBranchAddress("fqpi0dir2", &fqpi0dir2);
+    fiTQun->SetBranchAddress("fqpi0dirtot", &fqpi0dirtot);
+    fiTQun->SetBranchAddress("fqnmrfit", &fqnmrfit);
+    fiTQun->SetBranchAddress("fqmrpos", &fqmrpos);
+    fiTQun->SetBranchAddress("fqmrdir", &fqmrdir);
+    fiTQun->SetBranchAddress("fqmsnfit", &fqmsnfit);
+    fiTQun->SetBranchAddress("fqmspos", &fqmspos);
+    fiTQun->SetBranchAddress("fqmsdir", &fqmsdir);
+    fiTQun->SetBranchAddress("fqtestn1r", &fqtestn1r);
+    fiTQun->SetBranchAddress("fqtest1rpos", &fqtest1rpos);
+    fiTQun->SetBranchAddress("fqtest1rdir", &fqtest1rdir);
+    fiTQun->SetBranchAddress("fqtestnpi0", &fqtestnpi0);
+    fiTQun->SetBranchAddress("fqtestpi0pos", &fqtestpi0pos);
+    fiTQun->SetBranchAddress("fqtestpi0dir1", &fqtestpi0dir1);
+    fiTQun->SetBranchAddress("fqtestpi0dir2", &fqtestpi0dir2);
+    fiTQun->SetBranchAddress("fqtestpi0dirtot", &fqtestpi0dirtot);
+
+    // gets the total number of entries
+    int fqEntries = fiTQun->GetEntries();
+
+    double offset = 2151.035; // particle gun y-offset of position in centimeters
+
+    // for each entry in the fiTQun input
+    // changes the fiTQun output's WCSim coordinates to the global nuPRISM coordinate geometry
+    for (int entry=0;entry<fqEntries;entry++) {
+        fiTQun->GetEntry(entry);
+        // time-window information
+        for (int i=0;i<fqntwnd;i++) {
+            for (int axis=0;axis<3;axis++) {
+                if (axis == 0) { // set the x-axis to the z-axis
+                    fqtwnd_prftposCv[i][0] = fqtwnd_prftpos[i][axis];
+                } else if (axis == 1) { // set the y-axis to the x-axis
+                    fqtwnd_prftposCv[i][1] = fqtwnd_prftpos[i][axis];
+                } else if (axis == 2) { // set the z-axis to the y-axis
+                    fqtwnd_prftposCv[i][2] = fqtwnd_prftpos[i][axis];
+                }
+            }
+        }
+        // 1-ring fits
+        for (int i=0;i<fqnse;i++) {
+            for (int j=0;j<7;j++) {
+                for (int axis=0;axis<3;axis++) {
+                    if (axis == 0) {
+                        fq1rposCv[i][j][0] = fq1rpos[i][j][axis];
+                        fq1rdirCv[i][j][0] = fq1rdir[i][j][axis];
+                    } else if (axis == 1) {
+                        fq1rposCv[i][j][1] = fq1rpos[i][j][axis];
+                        fq1rdirCv[i][j][1] = fq1rdir[i][j][axis];
+                    } else if (axis == 2) {
+                        fq1rposCv[i][j][2] = fq1rpos[i][j][axis];
+                        fq1rdirCv[i][j][2] = fq1rdir[i][j][axis];
+                    }
+                }
+            }
+        }
+        // Pi0 fits
+        for (int i=0;i<2;i++) {
+            for (int axis=0;axis<3;axis++) {
+                if (axis == 0) {
+                    fqpi0posCv[i][0] = fqpi0pos[i][axis];
+                    fqpi0dir1Cv[i][0] = fqpi0dir1[i][axis];
+                    fqpi0dir2Cv[i][0] = fqpi0dir2[i][axis];
+                    fqpi0dirtotCv[i][0] = fqpi0dirtot[i][axis];
+                } else if (axis == 1) {
+                    fqpi0posCv[i][1] = fqpi0pos[i][axis];
+                    fqpi0dir1Cv[i][1] = fqpi0dir1[i][axis];
+                    fqpi0dir2Cv[i][1] = fqpi0dir2[i][axis];
+                    fqpi0dirtotCv[i][1] = fqpi0dirtot[i][axis];
+                } else if (axis == 2) {
+                    fqpi0posCv[i][2] = fqpi0pos[i][axis];
+                    fqpi0dir1Cv[i][2] = fqpi0dir1[i][axis];
+                    fqpi0dir2Cv[i][2] = fqpi0dir2[i][axis];
+                    fqpi0dirtotCv[i][2] = fqpi0dirtot[i][axis];
+                }
+            }
+        }
+        // multi-ring fits
+        for (int i=0;i<fqnmrfit;i++) {
+            for (int j=0;j<6;j++) {
+                for (int axis=0;axis<3;axis++) {
+                    if (axis == 0) {
+                        fqmrposCv[i][j][0] = fqmrpos[i][j][axis];
+                        fqmrdirCv[i][j][0] = fqmrdir[i][j][axis]; 
+                    } else if (axis == 1) {
+                        fqmrposCv[i][j][1] = fqmrpos[i][j][axis];
+                        fqmrdirCv[i][j][1] = fqmrdir[i][j][axis];
+                    } else if (axis == 2) {
+                        fqmrposCv[i][j][2] = fqmrpos[i][j][axis];
+                        fqmrdirCv[i][j][2] = fqmrdir[i][j][axis];
+                    }
+                }
+            }
+        }
+        // multi-segment muon fits
+        for (int i=0;i<fqmsnfit;i++) {
+            for (int j=0;j<20;j++) {
+                for (int axis=0;axis<3;axis++) {
+                    if (axis == 0) {
+                        fqmsposCv[i][j][0] = fqmspos[i][j][axis];
+                        fqmsdirCv[i][j][0] = fqmsdir[i][j][axis];
+                    } else if (axis == 1) {
+                        fqmsposCv[i][j][1] = fqmspos[i][j][axis];
+                        fqmsdirCv[i][j][1] = fqmsdir[i][j][axis];
+                    } else if (axis == 2) {
+                        fqmsposCv[i][j][2] = fqmspos[i][j][axis];
+                        fqmsdirCv[i][j][2] = fqmsdir[i][j][axis];
+                    }
+                }
+            }
+        }
+        // test 1-ring fits
+        for (int i=0;i<fqtestn1r;i++) {
+            for (int axis=0;axis<3;axis++) {
+                if (axis == 0) {
+                    fqtest1rposCv[i][0] = fqtest1rpos[i][axis];
+                    fqtest1rdirCv[i][0] = fqtest1rdir[i][axis];
+                } else if (axis == 1) {
+                    fqtest1rposCv[i][1] = fqtest1rpos[i][axis];
+                    fqtest1rdirCv[i][1] = fqtest1rdir[i][axis];
+                } else if (axis == 2) {
+                    fqtest1rposCv[i][2] = fqtest1rpos[i][axis];
+                    fqtest1rdirCv[i][2] = fqtest1rdir[i][axis];
+                }
+            }
+        }
+        // test Pi0 fits
+        for (int i=0;i<fqtestnpi0;i++) {
+            for (int axis=0;axis<3;axis++) {
+                if (axis == 0) {
+                    fqtestpi0posCv[i][0] = fqtestpi0pos[i][axis];
+                    fqtestpi0dir1Cv[i][0] = fqtestpi0dir1[i][axis];
+                    fqtestpi0dir2Cv[i][0] = fqtestpi0dir2[i][axis];
+                    fqtestpi0dirtotCv[i][0] = fqtestpi0dirtot[i][axis];
+                } else if (axis == 1) {
+                    fqtestpi0posCv[i][1] = fqtestpi0pos[i][axis];
+                    fqtestpi0dir1Cv[i][1] = fqtestpi0dir1[i][axis];
+                    fqtestpi0dir2Cv[i][1] = fqtestpi0dir2[i][axis];
+                    fqtestpi0dirtotCv[i][1] = fqtestpi0dirtot[i][axis];
+                } else if (axis == 2) {
+                    fqtestpi0posCv[i][2] = fqtestpi0pos[i][axis];
+                    fqtestpi0dir1Cv[i][2] = fqtestpi0dir1[i][axis];
+                    fqtestpi0dir2Cv[i][2] = fqtestpi0dir2[i][axis];
+                    fqtestpi0dirtotCv[i][2] = fqtestpi0dirtot[i][axis];
+                }
+            }
+        }
+        // fill all branches for each entry
+        bfqtwnd_prftpos->Fill();
+        bfq1rpos->Fill();
+        bfq1rdir->Fill();
+        bfqpi0pos->Fill();
+        bfqpi0dir1->Fill();
+        bfqpi0dir2->Fill();
+        bfqpi0dirtot->Fill();
+        bfqmrpos->Fill();
+        bfqmrdir->Fill();
+        bfqmspos->Fill();
+        bfqmsdir->Fill();
+        bfqtest1rpos->Fill();
+        bfqtest1rdir->Fill();
+        bfqtestpi0pos->Fill();
+        bfqtestpi0dir1->Fill();
+        bfqtestpi0dir2->Fill();
+        bfqtestpi0dirtot->Fill();
+    }
+
+    fiTQunCv->Write("",TObject::kOverwrite);
+
+}
+
+/* extracts the true information from the wcsimT tree
+ * the position and direction information is converted to nuPRISM geometry
+ * and then all the information are saved in the new wcsimEx tree
+ */
+void extractTruth(TTree* wcsimT, TTree* wcsimEx) {    
+
+    WCSimRootTrigger * wcsimrootTrigger;
+    WCSimRootEvent * wcsimrootEvent;
+    wcsimrootEvent = new WCSimRootEvent();
+    wcsimT->SetBranchAddress("wcsimrootevent" ,&wcsimrootEvent);
+
+    // initializes variables
+    const Int_t maxtrack = 200;
+    Int_t ntrack;
+    Int_t parent[maxtrack];
+    Int_t pid[maxtrack];
+    Double_t dir[maxtrack][4];
+    Double_t start[maxtrack][4];
+    Double_t stop[maxtrack][4];
+    Double_t mom[maxtrack];
+    Double_t mass[maxtrack];
+    Double_t energy[maxtrack];
+    Double_t startvol[maxtrack];
+    Double_t stopvol[maxtrack];
+    Double_t time[maxtrack];
+
+    // sets output Ttree to above variables
+    wcsimEx->Branch("ntrack",&ntrack,"ntrack/I");
+    wcsimEx->Branch("parent",parent,"parent[ntrack]/I");
+    wcsimEx->Branch("pid",pid,"pid[ntrack]/I");
+    wcsimEx->Branch("dir",dir,"dir[ntrack][4]/D");
+    wcsimEx->Branch("start",start,"start[ntrack][4]/D");
+    wcsimEx->Branch("stop",stop,"stop[ntrack][4]/D");
+    wcsimEx->Branch("mom",mom,"mom[ntrack]/D");
+    wcsimEx->Branch("mass",mass,"mass[ntrack]/D");
+    wcsimEx->Branch("energy",energy,"energy[ntrack]/D");
+    wcsimEx->Branch("startvol",startvol,"startvol[ntrack]/D");
+    wcsimEx->Branch("stopvol",stopvol,"stopvol[ntrack]/D");
+    wcsimEx->Branch("time",time,"time[ntrack]/D");
+
+    // for each event in the wcsimT input
+    int Entries = wcsimT->GetEntries();
+    for (int ev=0; ev<Entries; ev++) {
+        wcsimT->GetEvent(ev);
+        wcsimrootTrigger = wcsimrootEvent->GetTrigger(0);
+        ntrack = wcsimrootTrigger->GetNtrack();
+        if(ntrack>0) {
+            // Loop through elements in the TClonesArray of WCSimTracks
+            // for each particle in the event set the respective variable's information
+            for (int par=0; par<ntrack; par++) {
+                // wcsimroottrack holds all info about particle
+                TObject *element = (wcsimrootTrigger->GetTracks())->At(par);
+                WCSimRootTrack *wcsimroottrack = dynamic_cast<WCSimRootTrack*>(element);
+                for (int axis=0;axis<4;axis++) {
+                    if (axis == 0) { // set wcsim x-axis to nuPRISM x-axis
+                        start[par][0] = wcsimroottrack->GetStart(axis)/100;
+                        stop[par][0] = wcsimroottrack->GetStop(axis)/100;
+                        dir[par][0] = wcsimroottrack->GetDir(axis);
+                    } else if (axis == 1) { // set wcsim y-axis to nuPRISM y-axis
+                        start[par][1] = wcsimroottrack->GetStart(axis)/100;
+                        stop[par][1] = wcsimroottrack->GetStop(axis)/100;
+                        dir[par][1] = wcsimroottrack->GetDir(axis);
+                    } else if (axis == 2) { // set wcsim z-axis to nuPRISM z-axis
+                        start[par][2] = wcsimroottrack->GetStart(axis)/100;
+                        stop[par][2] = wcsimroottrack->GetStop(axis)/100;
+                        dir[par][2] = wcsimroottrack->GetDir(axis);
+                    } else if (axis == 3) {
+                        start[par][3] = wcsimroottrack->GetStart(axis)/100;
+                        stop[par][3] = wcsimroottrack->GetStop(axis)/100;
+                        dir[par][3] = wcsimroottrack->GetDir(axis);
+                    }
+                }
+                parent[par]=wcsimroottrack->GetParenttype();
+                pid[par]=wcsimroottrack->GetIpnu();
+                mom[par]=wcsimroottrack->GetP();
+                mass[par]=wcsimroottrack->GetM();
+                energy[par]=wcsimroottrack->GetE();
+                startvol[par]=wcsimroottrack->GetStartvol();
+                stopvol[par]=wcsimroottrack->GetStopvol();
+                time[par]=wcsimroottrack->GetTime();
+            }
+            // fill the wcsimEx with all the current event's information in the current loop
+            wcsimEx->Fill();
+        }
+    }
+
+    wcsimEx->Write("",TObject::kOverwrite);
+
+}
+
+int convertNuPrism(char* input, char* output, bool dofiTQun=0, bool copy=0){
+
+    char *filename = input;
+    char *outfilename = output;
+    bool toCopy = copy;
+    bool useFiTQun = dofiTQun;
+
+    TFile *file = new TFile(filename,"read");
+    if (!file->IsOpen()){
+        std::cout << "Error, could not open input file: " << filename << std::endl;
+        exit(-1);
+    }
+
+    // creates new trees for output file
+    TFile* outFile = TFile::Open(outfilename, "RECREATE");
+    TTree* fiTQunCv = new TTree("fiTQunCv", "fiTQun Converted Geometry");
+    TTree* wcsimEx = new TTree("wcsimEx","Converted Particle Info");
+
+    // gets the old trees from the fiTQun file
+    TTree* wcsimT = (TTree*) file->Get("wcsimT");
+    TTree* wcsimGeoT = (TTree*) file->Get("wcsimGeoT");
+    TTree* fiTQun = (TTree*) file->Get("fiTQun"); // gets the old fiTQun information
+    TTree* Settings = (TTree*) file->Get("Settings");
+
+    // prepares trees to be copied
+    TTree* newEventTree;
+    TTree* newGeomTree;
+    TTree* newSettings;
+    if (toCopy) {
+        newEventTree = wcsimT->CloneTree();
+        newGeomTree = wcsimGeoT->CloneTree();
+        if (Settings) {
+            newSettings = Settings->CloneTree();
+        }
+    }
+
+    if(useFiTQun) convertfiTQun(fiTQun, fiTQunCv);
+    extractTruth(wcsimT, wcsimEx);
+
+    // copies the other trees
+    if (toCopy){
+        newEventTree->Write();
+        newGeomTree->Write();
+        if (Settings) {
+            newSettings->Write();
+        }
+    }
+
+    outFile->Close();
+    return 0;
+}
+

--- a/src/WCSimConstructGeometryTables.cc
+++ b/src/WCSimConstructGeometryTables.cc
@@ -43,15 +43,21 @@ void WCSimDetectorConstruction::GetWCGeom
     // This information will later be written to the geometry file
     // (Alternatively one might define accessible constants)
   
-    if ((aPV->GetName() == "WCBarrel") ||
-        (aPV->GetName() == "WorldBox")) {    // last condition is the HyperK Envelope name.
+    if ((aPV->GetName() == "WCBox")) {    // last condition is the HyperK Envelope name.
     // Stash info in data member
-    WCOffset = G4ThreeVector(aTransform.getTranslation().getX()/cm,
+        WCOffset = G4ThreeVector(aTransform.getTranslation().getX()/cm,
 			     aTransform.getTranslation().getY()/cm,
 			     aTransform.getTranslation().getZ()/cm);
+        WCXRotation = G4ThreeVector(aTransform.getRotation().xx(), aTransform.getRotation().xy(), aTransform.getRotation().xz());
+        WCYRotation = G4ThreeVector(aTransform.getRotation().yx(), aTransform.getRotation().yy(), aTransform.getRotation().yz());
+        WCZRotation = G4ThreeVector(aTransform.getRotation().zx(), aTransform.getRotation().zy(), aTransform.getRotation().zz());
     }
 
-	
+//	WCRotation = G4ThreeVector(aTransform.getTranslation().getX()/cm,
+//			     aTransform.getTranslation().getY()/cm,
+//			     aTransform.getTranslation().getZ()/cm);
+//    }
+
 
     // Stash info in data member
     // AH Need to store this in CM for it to be understood by SK code
@@ -87,7 +93,6 @@ void WCSimDetectorConstruction::GetWCGeom
       WCCylInfo[0] = xmax-xmin;
       WCCylInfo[1] = ymax-ymin;
       WCCylInfo[2] = zmax-zmin;
-      //      G4cout << "determin hight: " << zmin << "  " << zmax << " " << aPV->GetName()<<" " << z  << G4endl;
   } 
 }
 

--- a/src/WCSimConstructGeometryTables.cc
+++ b/src/WCSimConstructGeometryTables.cc
@@ -53,16 +53,9 @@ void WCSimDetectorConstruction::GetWCGeom
         WCZRotation = G4ThreeVector(aTransform.getRotation().zx(), aTransform.getRotation().zy(), aTransform.getRotation().zz());
     }
 
-//	WCRotation = G4ThreeVector(aTransform.getTranslation().getX()/cm,
-//			     aTransform.getTranslation().getY()/cm,
-//			     aTransform.getTranslation().getZ()/cm);
-//    }
-
-
     // Stash info in data member
     // AH Need to store this in CM for it to be understood by SK code
     WCPMTSize = WCPMTRadius/cm;// I think this is just a variable no if needed
-
 
     // Note WC can be off-center... get both extremities
     static G4float zmin=100000,zmax=-100000.;
@@ -86,8 +79,7 @@ void WCSimDetectorConstruction::GetWCGeom
       if (y>ymax){ymax=y;}
 
       if (z<zmin){zmin=z;}
-      if (z>zmax){zmax=z;}
-     
+      if (z>zmax){zmax=z;} 
 
  
       WCCylInfo[0] = xmax-xmin;

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -363,7 +363,7 @@ void WCSimDetectorConstruction::SetNuPrismGeometry(G4String PMTType, G4double PM
 
 void WCSimDetectorConstruction::SetDefaultNuPrismGeometry()
 {
-    SetNuPrismGeometry("PMT10inch", 40.0, 10*m, 6*m, 52.48*m);
+    SetNuPrismGeometry("PMT8inch", 40.0, 10*m, 6*m);
 }
 
 

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -337,7 +337,7 @@ void WCSimDetectorConstruction::DUSEL_200kton_12inch_HQE_14perCent()
   WCAddGd               = false;
 }
 
-void WCSimDetectorConstruction::SetNuPrismGeometry(G4String PMTType, G4double PMTCoverage, G4double detectorHeight, G4double detectorDiameter)
+void WCSimDetectorConstruction::SetNuPrismGeometry(G4String PMTType, G4double PMTCoverage, G4double detectorHeight, G4double detectorDiameter, G4double verticalPosition)
 {
     WCSimPMTObject * PMT = CreatePMTObject(PMTType);
     WCPMTName = PMT->GetPMTName();
@@ -347,6 +347,7 @@ void WCSimDetectorConstruction::SetNuPrismGeometry(G4String PMTType, G4double PM
 
     WCIDHeight               = detectorHeight;
     WCIDDiameter             = detectorDiameter;
+    WCIDVerticalPosition     = verticalPosition;
 
     WCBarrelPMTOffset     = WCPMTRadius;
     WCPMTperCellHorizontal = 1.0;
@@ -363,7 +364,7 @@ void WCSimDetectorConstruction::SetNuPrismGeometry(G4String PMTType, G4double PM
 
 void WCSimDetectorConstruction::SetDefaultNuPrismGeometry()
 {
-    SetNuPrismGeometry("PMT8inch", 40.0, 10*m, 6*m);
+    SetNuPrismGeometry("PMT8inch", 40.0, 10*m, 6*m, 0*m);
 }
 
 

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -337,7 +337,34 @@ void WCSimDetectorConstruction::DUSEL_200kton_12inch_HQE_14perCent()
   WCAddGd               = false;
 }
 
+void WCSimDetectorConstruction::SetNuPrismGeometry(G4String PMTType, G4double PMTCoverage, G4double detectorHeight, G4double detectorDiameter)
+{
+    WCSimPMTObject * PMT = CreatePMTObject(PMTType);
+    WCPMTName = PMT->GetPMTName();
+    WCPMTExposeHeight = PMT->GetExposeHeight();
+    WCPMTRadius = PMT->GetRadius();
+    WCPMTGlassThickness = PMT->GetPMTGlassThickness();
 
+    WCIDHeight               = detectorHeight;
+    WCIDDiameter             = detectorDiameter;
+
+    WCBarrelPMTOffset     = WCPMTRadius;
+    WCPMTperCellHorizontal = 1.0;
+    WCPMTperCellVertical   = 1.0;
+    WCPMTPercentCoverage   = PMTCoverage;
+    WCBarrelNumPMTHorizontal = round(WCIDDiameter*sqrt(pi*WCPMTPercentCoverage/100.0)/WCPMTRadius);
+
+    WCBarrelNRings        = round(((WCBarrelNumPMTHorizontal*((WCIDHeight-2*WCBarrelPMTOffset)/(pi*WCIDDiameter)))/WCPMTperCellVertical));
+    WCCapPMTSpacing       = (pi*WCIDDiameter/WCBarrelNumPMTHorizontal);
+    WCCapEdgeLimit        = WCIDDiameter/2.0 - WCPMTRadius;
+    WCBlackSheetThickness = 2.0*cm;
+    WCAddGd               = false;
+}
+
+void WCSimDetectorConstruction::SetDefaultNuPrismGeometry()
+{
+    SetNuPrismGeometry("PMT10inch", 40.0, 10*m, 6*m, 52.48*m);
+}
 
 
 

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -113,6 +113,38 @@ WCSimDetectorConstruction::~WCSimDetectorConstruction(){
   fpmts.clear();
 }
 
+G4ThreeVector WCSimDetectorConstruction::GetTranslationFromSettings()
+{
+    TFile* inFile = TFile::Open(fInputSettingsFilename);
+    if (!inFile){
+        G4ThreeVector trans;
+        return trans;
+    }
+
+    fSettingsTree = (TTree*) inFile->Get("Settings");
+    if (!fSettingsTree){
+        G4ThreeVector trans;
+        return trans;
+    }
+
+    float NuBeamAng;
+    float NuIdfdPos[3];
+    for(int i = 0; i < 3; ++i) NuIdfdPos[i] = 0;
+    fSettingsTree->SetBranchAddress("NuIdfdPos",NuIdfdPos); 
+    fSettingsTree->SetBranchAddress("NuBeamAng",&NuBeamAng); 
+
+    fSettingsTree->GetEntry(0);
+
+    G4ThreeVector trans(0, (NuIdfdPos[1] + TMath::Tan(NuBeamAng)*600.0), NuIdfdPos[2] + 600.0);
+
+    inFile->Close();
+    fInputSettingsFilename = "";
+    fSettingsTree = NULL;
+
+    return trans;
+
+}
+
 G4VPhysicalVolume* WCSimDetectorConstruction::Construct()
 {  
   G4GeometryManager::GetInstance()->OpenGeometry();
@@ -147,15 +179,17 @@ G4VPhysicalVolume* WCSimDetectorConstruction::Construct()
   // Now make the detector Hall.  The lengths of the subdectors 
   // were set above.
 
+  G4ThreeVector position = GetTranslationFromSettings();
+
   G4double expHallLength = 3.*WCLength; //jl145 - extra space to simulate cosmic muons more easily
 
   G4cout << " expHallLength = " << expHallLength / m << G4endl;
   G4double expHallHalfLength = 0.5*expHallLength;
 
   G4Box* solidExpHall = new G4Box("expHall",
-				  expHallHalfLength,
-				  expHallHalfLength,
-				  expHallHalfLength);
+				  expHallHalfLength + fabs(position.x())*cm,
+				  expHallHalfLength + fabs(position.y())*cm,
+				  expHallHalfLength + fabs(position.z())*cm);
   
   G4LogicalVolume* logicExpHall = 
     new G4LogicalVolume(solidExpHall,
@@ -183,12 +217,20 @@ G4VPhysicalVolume* WCSimDetectorConstruction::Construct()
   // WC Box, nice to turn on for x and y views to provide a frame:
 
   G4RotationMatrix* rotationMatrix = new G4RotationMatrix;
+  G4ThreeVector genPosition = G4ThreeVector(0., 0., WCPosition);
 
   if(isNuPrism){
       rotationMatrix->rotateX(90.*deg);
+      rotationMatrix->rotateY(0.*deg);
+      rotationMatrix->rotateZ(0.*deg);
+      genPosition.setX(position.x()*cm);
+      genPosition.setY(position.y()*cm);
+      genPosition.setZ(position.z()*cm);
   }
- 
-  G4ThreeVector genPosition = G4ThreeVector(0., 0., WCPosition);
+
+  std::cout << "genPosition.x() = " << genPosition.x() << std::endl; 
+  std::cout << "genPosition.y() = " << genPosition.y() << std::endl; 
+  std::cout << "genPosition.z() = " << genPosition.z() << std::endl; 
 
   G4Transform3D transform(*rotationMatrix, genPosition);
 

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -28,6 +28,7 @@ WCSimDetectorConstruction::WCSimDetectorConstruction(G4int DetConfig,WCSimTuning
   // Decide if (only for the case of !1kT detector) should be upright or horizontal
   isUpright = false;
   isHyperK  = false;
+  isNuPrism  = false;
 
   debugMode = false;
 //-----------------------------------------------------
@@ -181,14 +182,18 @@ G4VPhysicalVolume* WCSimDetectorConstruction::Construct()
   // Water Cherenkov Detector (WC) mother volume
   // WC Box, nice to turn on for x and y views to provide a frame:
 
-	  //G4RotationMatrix* rotationMatrix = new G4RotationMatrix;
-	  //rotationMatrix->rotateX(90.*deg);
-	  //rotationMatrix->rotateZ(90.*deg);
+  G4RotationMatrix* rotationMatrix = new G4RotationMatrix;
 
+  if(isNuPrism){
+      rotationMatrix->rotateX(90.*deg);
+  }
+ 
   G4ThreeVector genPosition = G4ThreeVector(0., 0., WCPosition);
+
+  G4Transform3D transform(*rotationMatrix, genPosition);
+
   G4VPhysicalVolume* physiWCBox = 
-    new G4PVPlacement(0,
-		      genPosition,
+    new G4PVPlacement(transform,
 		      logicWCBox,
 		      "WCBox",
 		      logicExpHall,

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -113,37 +113,37 @@ WCSimDetectorConstruction::~WCSimDetectorConstruction(){
   fpmts.clear();
 }
 
-G4ThreeVector WCSimDetectorConstruction::GetTranslationFromSettings()
-{
-    TFile* inFile = TFile::Open(fInputSettingsFilename);
-    if (!inFile){
-        G4ThreeVector trans;
-        return trans;
-    }
-
-    fSettingsTree = (TTree*) inFile->Get("Settings");
-    if (!fSettingsTree){
-        G4ThreeVector trans;
-        return trans;
-    }
-
-    float NuBeamAng;
-    float NuIdfdPos[3];
-    for(int i = 0; i < 3; ++i) NuIdfdPos[i] = 0;
-    fSettingsTree->SetBranchAddress("NuIdfdPos",NuIdfdPos); 
-    fSettingsTree->SetBranchAddress("NuBeamAng",&NuBeamAng); 
-
-    fSettingsTree->GetEntry(0);
-
-    G4ThreeVector trans(0, (NuIdfdPos[1] + TMath::Tan(NuBeamAng)*600.0), NuIdfdPos[2] + 600.0);
-
-    inFile->Close();
-    fInputSettingsFilename = "";
-    fSettingsTree = NULL;
-
-    return trans;
-
-}
+//G4ThreeVector WCSimDetectorConstruction::GetTranslationFromSettings()
+//{
+//    TFile* inFile = TFile::Open(fInputSettingsFilename);
+//    if (!inFile){
+//        G4ThreeVector trans;
+//        return trans;
+//    }
+//
+//    fSettingsTree = (TTree*) inFile->Get("Settings");
+//    if (!fSettingsTree){
+//        G4ThreeVector trans;
+//        return trans;
+//    }
+//
+//    float NuBeamAng;
+//    float NuIdfdPos[3];
+//    for(int i = 0; i < 3; ++i) NuIdfdPos[i] = 0;
+//    fSettingsTree->SetBranchAddress("NuIdfdPos",NuIdfdPos); 
+//    fSettingsTree->SetBranchAddress("NuBeamAng",&NuBeamAng); 
+//
+//    fSettingsTree->GetEntry(0);
+//
+//    G4ThreeVector trans(0, (NuIdfdPos[1] + TMath::Tan(NuBeamAng)*600.0), NuIdfdPos[2] + 600.0);
+//
+//    inFile->Close();
+//    fInputSettingsFilename = "";
+//    fSettingsTree = NULL;
+//
+//    return trans;
+//
+//}
 
 G4VPhysicalVolume* WCSimDetectorConstruction::Construct()
 {  
@@ -179,7 +179,7 @@ G4VPhysicalVolume* WCSimDetectorConstruction::Construct()
   // Now make the detector Hall.  The lengths of the subdectors 
   // were set above.
 
-  G4ThreeVector position = GetTranslationFromSettings();
+  G4ThreeVector position(0,0,0);// = GetTranslationFromSettings();
 
   G4double expHallLength = 3.*WCLength; //jl145 - extra space to simulate cosmic muons more easily
 
@@ -231,6 +231,10 @@ G4VPhysicalVolume* WCSimDetectorConstruction::Construct()
   std::cout << "genPosition.x() = " << genPosition.x() << std::endl; 
   std::cout << "genPosition.y() = " << genPosition.y() << std::endl; 
   std::cout << "genPosition.z() = " << genPosition.z() << std::endl; 
+  std::cout << "genPosition.x() = " << position.x() << std::endl; 
+  std::cout << "genPosition.y() = " << position.y() << std::endl; 
+  std::cout << "genPosition.z() = " << position.z() << std::endl; 
+
 
   G4Transform3D transform(*rotationMatrix, genPosition);
 

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -181,15 +181,20 @@ G4VPhysicalVolume* WCSimDetectorConstruction::Construct()
 
   G4ThreeVector position(0,0,0);// = GetTranslationFromSettings();
 
+  if(isNuPrism) position.setY(WCIDVerticalPosition);
+
+  std::cout << "position Y = " << position.y() << std::endl;
+
+
   G4double expHallLength = 3.*WCLength; //jl145 - extra space to simulate cosmic muons more easily
 
   G4cout << " expHallLength = " << expHallLength / m << G4endl;
   G4double expHallHalfLength = 0.5*expHallLength;
 
   G4Box* solidExpHall = new G4Box("expHall",
-				  expHallHalfLength + fabs(position.x())*cm,
-				  expHallHalfLength + fabs(position.y())*cm,
-				  expHallHalfLength + fabs(position.z())*cm);
+				  expHallHalfLength + fabs(position.x()),
+				  expHallHalfLength + fabs(position.y()),
+				  expHallHalfLength + fabs(position.z()));
   
   G4LogicalVolume* logicExpHall = 
     new G4LogicalVolume(solidExpHall,
@@ -223,18 +228,10 @@ G4VPhysicalVolume* WCSimDetectorConstruction::Construct()
       rotationMatrix->rotateX(90.*deg);
       rotationMatrix->rotateY(0.*deg);
       rotationMatrix->rotateZ(0.*deg);
-      genPosition.setX(position.x()*cm);
-      genPosition.setY(position.y()*cm);
-      genPosition.setZ(position.z()*cm);
+      genPosition.setX(position.x());
+      genPosition.setY(position.y());
+      genPosition.setZ(position.z());
   }
-
-  std::cout << "genPosition.x() = " << genPosition.x() << std::endl; 
-  std::cout << "genPosition.y() = " << genPosition.y() << std::endl; 
-  std::cout << "genPosition.z() = " << genPosition.z() << std::endl; 
-  std::cout << "genPosition.x() = " << position.x() << std::endl; 
-  std::cout << "genPosition.y() = " << position.y() << std::endl; 
-  std::cout << "genPosition.z() = " << position.z() << std::endl; 
-
 
   G4Transform3D transform(*rotationMatrix, genPosition);
 

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -114,6 +114,15 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
   SetPMTCoverage->SetParameterName("PMTCoverage", false);
   SetPMTCoverage->SetDefaultValue("40");
 
+  // Set the vertical position of the nuPRISM-lite detector
+  SetDetectorVerticalPosition = new G4UIcmdWithADoubleAndUnit("/WCSim/nuPRISM/SetDetectorVerticalPosition", this);
+  SetDetectorVerticalPosition->SetGuidance("Set the vertical position of the nuPRISM inner detector (unit mm cm m).");
+  SetDetectorVerticalPosition->SetGuidance("The default will be 0m, so particle guns are easy to create.");
+  SetDetectorVerticalPosition->SetParameterName("DetectorVerticalPosition", false);
+  SetDetectorVerticalPosition->SetDefaultValue(0.0);
+  SetDetectorVerticalPosition->SetUnitCategory("Length");
+  SetDetectorVerticalPosition->SetDefaultUnit("m");
+
   // Set the height of the nuPRISM-lite detector
   SetDetectorHeight = new G4UIcmdWithADoubleAndUnit("/WCSim/nuPRISM/SetDetectorHeight", this);
   SetDetectorHeight->SetGuidance("Set the height of the nuPRISM inner detector (unit mm cm m).");
@@ -146,6 +155,7 @@ WCSimDetectorMessenger::~WCSimDetectorMessenger()
 
   delete SetDetectorDiameter;
   delete SetDetectorHeight;
+  delete SetDetectorVerticalPosition;
   delete SetPMTCoverage;
   delete SetPMTType;
 
@@ -259,12 +269,14 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
         if (command == SetPMTType) WCSimDetector->SetPMTType(newValue);
         else if (command == SetPMTCoverage) WCSimDetector->SetPMTCoverage(atof(newValue));
         else if (command == SetDetectorHeight) WCSimDetector->SetDetectorHeight(SetDetectorHeight->GetNewDoubleValue(newValue));
+        else if (command == SetDetectorVerticalPosition) WCSimDetector->SetDetectorVerticalPosition(SetDetectorVerticalPosition->GetNewDoubleValue(newValue));
         else if (command == SetDetectorDiameter) WCSimDetector->SetDetectorDiameter(SetDetectorDiameter->GetNewDoubleValue(newValue));
         else if (command == UpdateNuPrism){
             WCSimDetector->SetNuPrismGeometry(WCSimDetector->GetPMTType(),
                     WCSimDetector->GetPMTCoverage(),
                     WCSimDetector->GetWCIDHeight(),
-                    WCSimDetector->GetWCIDDiameter());
+                    WCSimDetector->GetWCIDDiameter(),
+                    WCSimDetector->GetWCIDVerticalPosition());
         }
     }
 

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -107,11 +107,6 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
   SetPMTType->SetCandidates("PMT8inch PMT10inchHQE PMT10inch PMT12inchHQE HPD20inchHQE PMT20inch");
   SetPMTType->SetDefaultValue("PMT10inch");
 
-  SettingsFile = new G4UIcmdWithAString("/WCSim/nuPRISM/SettingsFile", this);
-  SettingsFile->SetGuidance("Settings file to determine the nuPRISM translation from the Beam coordinate system - should be the same RooTrackerFile as used for input");
-  SettingsFile->SetParameterName("SettingsFile", false);
-  SettingsFile->SetDefaultValue("");
-
   // Next, the PMT coverage
   SetPMTCoverage = new G4UIcmdWithAString("/WCSim/nuPRISM/SetPMTPercentCoverage", this);
   SetPMTCoverage->SetGuidance("Set the PMT percentage coverage to be used for nuPRISM");
@@ -153,7 +148,6 @@ WCSimDetectorMessenger::~WCSimDetectorMessenger()
   delete SetDetectorHeight;
   delete SetPMTCoverage;
   delete SetPMTType;
-  delete SettingsFile;
 
   delete tubeCmd;
   delete distortionCmd;
@@ -266,7 +260,6 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
         else if (command == SetPMTCoverage) WCSimDetector->SetPMTCoverage(atof(newValue));
         else if (command == SetDetectorHeight) WCSimDetector->SetDetectorHeight(SetDetectorHeight->GetNewDoubleValue(newValue));
         else if (command == SetDetectorDiameter) WCSimDetector->SetDetectorDiameter(SetDetectorDiameter->GetNewDoubleValue(newValue));
-        else if (command == SettingsFile) WCSimDetector->SetInputSettingsFilename(newValue);
         else if (command == UpdateNuPrism){
             WCSimDetector->SetNuPrismGeometry(WCSimDetector->GetPMTType(),
                     WCSimDetector->GetPMTCoverage(),

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -97,14 +97,20 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
   SetPMTType = new G4UIcmdWithAString("/WCSim/nuPRISM/SetPMTType", this);
   SetPMTType->SetGuidance("Set the type of PMT to be used for nuPRISM");
   SetPMTType->SetGuidance("Available options are:\n"
+          "PMT8inch\n"
           "PMT10inchHQE\n"
           "PMT10inch\n"
           "PMT12inchHQE\n"
           "HPD20inchHQE\n"
           "PMT20inch\n");
   SetPMTType->SetParameterName("PMTType", false);
-  SetPMTType->SetCandidates("PMT10inchHQE PMT10inch PMT12inchHQE HPD20inchHQE PMT20inch");
+  SetPMTType->SetCandidates("PMT8inch PMT10inchHQE PMT10inch PMT12inchHQE HPD20inchHQE PMT20inch");
   SetPMTType->SetDefaultValue("PMT10inch");
+
+  SettingsFile = new G4UIcmdWithAString("/WCSim/nuPRISM/SettingsFile", this);
+  SettingsFile->SetGuidance("Settings file to determine the nuPRISM translation from the Beam coordinate system - should be the same RooTrackerFile as used for input");
+  SettingsFile->SetParameterName("SettingsFile", false);
+  SettingsFile->SetDefaultValue("");
 
   // Next, the PMT coverage
   SetPMTCoverage = new G4UIcmdWithAString("/WCSim/nuPRISM/SetPMTPercentCoverage", this);
@@ -147,6 +153,7 @@ WCSimDetectorMessenger::~WCSimDetectorMessenger()
   delete SetDetectorHeight;
   delete SetPMTCoverage;
   delete SetPMTType;
+  delete SettingsFile;
 
   delete tubeCmd;
   delete distortionCmd;
@@ -259,11 +266,12 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
         else if (command == SetPMTCoverage) WCSimDetector->SetPMTCoverage(atof(newValue));
         else if (command == SetDetectorHeight) WCSimDetector->SetDetectorHeight(SetDetectorHeight->GetNewDoubleValue(newValue));
         else if (command == SetDetectorDiameter) WCSimDetector->SetDetectorDiameter(SetDetectorDiameter->GetNewDoubleValue(newValue));
+        else if (command == SettingsFile) WCSimDetector->SetInputSettingsFilename(newValue);
         else if (command == UpdateNuPrism){
             WCSimDetector->SetNuPrismGeometry(WCSimDetector->GetPMTType(),
                     WCSimDetector->GetPMTCoverage(),
-                    WCSimDetector->GetDetectorHeight(),
-                    WCSimDetector->GetDetectorDiameter());
+                    WCSimDetector->GetWCIDHeight(),
+                    WCSimDetector->GetWCIDDiameter());
         }
     }
 

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -255,18 +255,19 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
 	// Calculate offset from neutrino generation plane to centre of nuPRISM detector (in metres)
         double z_offset = fNuPlanePos[2]/100.0 + fNuPrismRadius;
-        double y_offset = fNuPlanePos[1]/100.0 + (fNuPrismRadius/zDir)*yDir;//TMath::Tan(fNuBeamAng)*(fNuPrismRadius);
+        double y_offset = 0;//fNuPlanePos[1]/100.0 + (fNuPrismRadius/zDir)*yDir;
 
         //Subtract offset to get interaction position in WCSim coordinates
         xPos = fTmpRootrackerVtx->EvtVtx[0];
         yPos = fTmpRootrackerVtx->EvtVtx[1] - y_offset;
         zPos = fTmpRootrackerVtx->EvtVtx[2] - z_offset;
 
+
         //Check if event is outside detector; skip to next event if so; keep
         //loading events until one is found within the detector or there are
         //no more interaction to simulate for this event.
         //The current neut vector files do not correspond directly to the detector dimensions, so only keep those events within the detector
-        while (sqrt(pow(xPos,2)+pow(zPos,2))*m > (myDetector->GetWCIDDiameter()/2. - 20*cm) || (abs(yPos)*m > (myDetector->GetWCIDHeight()/2. - 20*cm))){
+        while (sqrt(pow(xPos,2)+pow(zPos,2))*m > (myDetector->GetWCIDDiameter()/2. - 20*cm) || (abs(yPos*m - myDetector->GetWCIDVerticalPosition()) > (myDetector->GetWCIDHeight()/2. - 20*cm))){
             //Load another event
             if (fEvNum<fNEntries){
                 fRooTrackerTree->GetEntry(fEvNum);
@@ -281,7 +282,7 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
             xPos = fTmpRootrackerVtx->EvtVtx[0]; 
             yPos = fTmpRootrackerVtx->EvtVtx[1] - y_offset; 
             zPos = fTmpRootrackerVtx->EvtVtx[2] - z_offset;
-        }
+        } 
 
         //Generate particles
         //i = 0 is the neutrino

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -138,7 +138,9 @@ void WCSimRunAction::FillGeoTree(){
   G4int numpmt;
   G4int orientation;
   Float_t offset[3];
-  
+ 
+  Float_t rotation[3];
+
   Int_t tubeNo;
   Float_t pos[3];
   Float_t rot[3];
@@ -175,7 +177,25 @@ void WCSimRunAction::FillGeoTree(){
   offset[1] = offset1[1];
   offset[2] = offset1[2];
   wcsimrootgeom-> SetWCOffset(offset[0],offset[1],offset[2]);
-  
+ 
+  G4ThreeVector rotation1= wcsimdetector->GetWCXRotation();
+  rotation[0] = rotation1[0];
+  rotation[1] = rotation1[1];
+  rotation[2] = rotation1[2];
+  wcsimrootgeom-> SetWCXRotation(rotation[0],rotation[1],rotation[2]);
+
+  G4ThreeVector rotation2= wcsimdetector->GetWCYRotation();
+  rotation[0] = rotation2[0];
+  rotation[1] = rotation2[1];
+  rotation[2] = rotation2[2];
+  wcsimrootgeom-> SetWCYRotation(rotation[0],rotation[1],rotation[2]);
+
+  G4ThreeVector rotation3= wcsimdetector->GetWCZRotation();
+  rotation[0] = rotation3[0];
+  rotation[1] = rotation3[1];
+  rotation[2] = rotation3[2];
+  wcsimrootgeom-> SetWCZRotation(rotation[0],rotation[1],rotation[2]);
+
   std::vector<WCSimPmtInfo*> *fpmts = wcsimdetector->Get_Pmts();
   WCSimPmtInfo *pmt;
   for (int i=0;i!=fpmts->size();i++){

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -98,6 +98,7 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* aRun)
     fRooTrackerOutputTree = new TTree("fRooTrackerOutputTree","Event Vertex Truth Array");
     fRooTrackerOutputTree->Branch("NVtx",&fNVtx,"NVtx/I");
     fRooTrackerOutputTree->Branch("NRooTrackerVtx","TClonesArray", &fVertices);
+    //fSettingsOutputTree = new TTree("SettingsTree","Settings tree");
   }      
 }
 

--- a/vis.mac
+++ b/vis.mac
@@ -26,7 +26,7 @@
 #/WCSim/HyperK/waterTank_Length 123750. mm # Equivalent length for 2 partitions
 #/WCSim/HyperK/waterTank_Length 247500. mm # Equivalent length for 1 partition
 
-#/WCSim/WCgeom DUSEL_100kton_10inch_40perCent
+/WCSim/WCgeom DUSEL_100kton_10inch_40perCent
 #/WCSim/WCgeom DUSEL_100kton_10inch_HQE_12perCent
 #/WCSim/WCgeom DUSEL_100kton_10inch_HQE_30perCent
 #/WCSim/WCgeom DUSEL_100kton_10inch_HQE_30perCent_Gd
@@ -34,6 +34,7 @@
 #/WCSim/WCgeom DUSEL_200kton_10inch_HQE_12perCent
 #/WCSim/WCgeom DUSEL_200kton_12inch_HQE_10perCent
 #/WCSim/WCgeom DUSEL_200kton_12inch_HQE_14perCent
+
 
 #Added for the PMT QE option 08/17/10 (XQ)
 # 1. Stacking only mean when the photon is generated
@@ -52,7 +53,7 @@
 # turn on or off the collection efficiency (05/27/11 XQ)
 #/WCSim/PMTCollEff on
 
-#/WCSim/Construct
+/WCSim/Construct
 
 # command to choose save or not save the pi0 info 07/03/10 (XQ)
 #/WCSim/SavePi0 true
@@ -71,10 +72,10 @@
 #/DarkRate/SetConvert 1.120 #For HPDs
 
 /vis/scene/create
-/vis/open OGLSX
+/vis/open DAWNFILE
 # You can also set the size and position of the window if you like
 #/vis/open OGLSX 1000x1000-0+0
-/vis/ogl/set/printSize 1000 1000
+#/vis/ogl/set/printSize 1000 1000
 
 # Vis Settings for SK
 /vis/viewer/zoom 1.2
@@ -115,5 +116,5 @@
 ## change the name of the output root file, default = wcsim.root
 /WCSimIO/RootFile wcsim.root
 
-/run/beamOn 100
+/run/beamOn 1
 #exit

--- a/vis.mac
+++ b/vis.mac
@@ -1,5 +1,4 @@
-# Visualization and setup macro 
-# This file is run by default if you just type WCSim and nothing else.
+# Sampe setup macro with no visualization
 
 /run/verbose 0
 /tracking/verbose 0
@@ -11,22 +10,25 @@
 # The tube size is fixed for SK to 20"
 # These are fixed geometries for validation
 #/WCSim/WCgeom SuperK
-# Currently by default the DUSEL configurations are 10 inch.
+# Currently by defualt the DUSEL configurations are 10 inch.
 # you can overide this with the WCPMTsize command.
 # WCPMTsize command commented out on 10/1/09 (CWW)
 #
-#
-#Added for detector length option (ONLY FOR HYPER-K GEOMETRY!!) 2014/07/29. This simulates a segment of the Hyper-K detector of a given length. 
 
-#/WCSim/WCgeom HyperK #default length is 49500 mm unless changed below.
+#Changes the length of the simulated volume. Is currently only set up for HyperK. 
 
-#/WCSim/HyperK/waterTank_Length 49500. mm # Equivalent length for 5 partitions(ie. will simulate a detector 1/10 of the HK length)
+#/WCSim/WCgeom HyperK #default length is 49500 mm unless changed in /WCSim/HK/PartionLength below.
+#/WCSim/WCgeom HyperK_withHPD #default length is 49500 mm unless changed in /WCSim/HK/PartionLength below.
+
+#/WCSim/HyperK/waterTank_Length 24750. mm # Equivalent length for 10 partitions
+#/WCSim/HyperK/waterTank_Length 49500. mm # Equivalent length for 5 partitions
 #/WCSim/HyperK/waterTank_Length 61875. mm # Equivalent length for 4 partitions
 #/WCSim/HyperK/waterTank_Length 82500. mm # Equivalent length for 3 partitions
 #/WCSim/HyperK/waterTank_Length 123750. mm # Equivalent length for 2 partitions
 #/WCSim/HyperK/waterTank_Length 247500. mm # Equivalent length for 1 partition
 
-/WCSim/WCgeom DUSEL_100kton_10inch_40perCent
+
+#/WCSim/WCgeom DUSEL_100kton_10inch_40perCent
 #/WCSim/WCgeom DUSEL_100kton_10inch_HQE_12perCent
 #/WCSim/WCgeom DUSEL_100kton_10inch_HQE_30perCent
 #/WCSim/WCgeom DUSEL_100kton_10inch_HQE_30perCent_Gd
@@ -35,41 +37,35 @@
 #/WCSim/WCgeom DUSEL_200kton_12inch_HQE_10perCent
 #/WCSim/WCgeom DUSEL_200kton_12inch_HQE_14perCent
 
+/WCSim/WCgeom nuPRISM
+#Select which PMT to use
+/WCSim/nuPRISM/SetPMTType PMT8inch
+/WCSim/nuPRISM/SetPMTPercentCoverage 20
+#Set height of nuPRISM inner detector
+/WCSim/nuPRISM/SetDetectorHeight 10. m
+#Set vertical position of inner detector, in beam coordinates
+/WCSim/nuPRISM/SetDetectorVerticalPosition -10. m
+#Set diameter of inner detector
+/WCSim/nuPRISM/SetDetectorDiameter 6. m
+/WCSim/nuPRISM/Update
+/WCSim/Construct
 
 #Added for the PMT QE option 08/17/10 (XQ)
 # 1. Stacking only mean when the photon is generated
 # the QE is applied to reduce the total number of photons
 # 2. Stacking and sensitivity detector
-# In the stacking part, the maximum QE is applied to reduce 
+# In the stacking part, the maximum QE is applied to reduce
 # the total number of photons
 # On the detector side, the rest of QE are applied according to QE/QE_max
 # distribution. This option is in particular important for the WLS
 # 3. The last option means all the QE are applied at the detector
-# Good for the low energy running. 
-/WCSim/PMTQEMethod     Stacking_Only 
+# Good for the low energy running.
+/WCSim/PMTQEMethod     Stacking_Only
 #/WCSim/PMTQEMethod     Stacking_And_SensitiveDetector
 #/WCSim/PMTQEMethod     SensitiveDetector_Only
 
-# turn on or off the collection efficiency (05/27/11 XQ)
-#/WCSim/PMTCollEff on
-
-/WCSim/Construct
-
 # command to choose save or not save the pi0 info 07/03/10 (XQ)
-#/WCSim/SavePi0 true
-/WCSim/SavePi0 false
-
-# command to set dark noise frequency 13/06/09
-# default dark noise frequency is 0 kHz
-/DarkRate/SetDarkRate 4.2 kHz #This is the value for SKI set in SKDETSIM.
-#/DarkRate/SetDarkRate 8.4 kHz #For HPDs, based	 on High QE dark rate from EGADS nov 2014
-
-# command to multiply the dark rate.
-# Convert dark noise frequency before digitization to after digitization by setting suitable factor
-# (14/03/10)
-# Factor of Normal PMT is 1.367
-/DarkRate/SetConvert 1.367
-#/DarkRate/SetConvert 1.120 #For HPDs
+/WCSim/SavePi0 true
 
 /vis/scene/create
 /vis/open DAWNFILE
@@ -102,19 +98,37 @@
 
 ## select the input nuance-formatted vector file
 ## you can of course use your own
-#/mygen/vecfile inputvectorfile
+# Or you can use the G4 Particle Gun below
+# Or a NEUT vector file
+/mygen/generator rootracker
+/mygen/vecfile ../genev_320a_1km_nd3_9xx_30818.root
 #/mygen/vecfile h2o.2km.001-009x3_G4.kin
 #/mygen/vecfile mu+.out
 
-# Or you can use the G4 Particle Gun
-/mygen/generator normal
-/gun/particle mu+
-/gun/energy 1000 MeV
-/gun/direction 0 1 0
-/gun/position 0 0 0 
+# command to set dark noise frequency 13/06/09
+# default dark noise frequency is 0 kHz
+/DarkRate/SetDarkRate 4.2 kHz #This is the value for SKI set in SKDETSIM.
+#/DarkRate/SetDarkRate 8.4 kHz #For HPDs, based on High QE dark rate from EGADS nov 2014
+
+# command to multiply the dark rate.
+# Convert dark noise frequency before digitization to after digitization by setting suitable factor
+# (14/03/10)
+# Factor of Normal PMT is 1.367
+/DarkRate/SetConvert 1.367
+#/DarkRate/SetConvert 1.120 #For HPDs
+
+#/gun/particle mu- 
+#/gun/particle pi0
+#/gun/energy 500 MeV
+#/gun/direction 0 0 1 
+#/gun/position 0 0 0  
 
 ## change the name of the output root file, default = wcsim.root
-/WCSimIO/RootFile wcsim.root
+/WCSimIO/RootFile wcsim_TestNEUT.root
+
+## Boolean to select whether to save the NEUT RooTracker vertices in the output file, provided you used
+## a NEUT vector file as input
+/WCSimIO/SaveRooTracker 1
 
 /run/beamOn 1
 #exit


### PR DESCRIPTION
This change adds the correct methods to build the nuPRISM detector in WCSim.

The detector is automatically built in the beam coordinate system, so that the cylinder axis is aligned with the y-axis.  The Z offset of the detector is subtracted in WCSim, so we do not need to create an 1km long world volume.    The Y position of nuPRISM is determined from the macro file.  Input RooTracker events are simulated at the Y position the interaction occurs at, so we can correctly simulate the changing off-axis angle.

The information on the rotation and translation of the detector with respect to the WCSim origin is stored in the RootGeom output of WCSim, and can be picked up by fiTQun to use in the reconstruction.