### PR TITLE
Feature/geometry transformation

### DIFF
--- a/include/WCSimRootGeom.hh
+++ b/include/WCSimRootGeom.hh
@@ -59,11 +59,8 @@ private:
   Float_t                fWCPMTRadius; // Radius of PMT
   Int_t                  fWCNumPMT;   // Number of PMTs
   Float_t                fWCOffset[3]; // Offset of barrel center in global coords
-  Float_t                fWCXRotation[3]; // Barrel local axis in global coords
-  Float_t                fWCYRotation[3]; // Barrel local axis in global coords
-  Float_t                fWCZRotation[3]; // Barrel local axis in global coords
 
-   Int_t                  fOrientation; //Orientation o detector, 0 is 2km horizontal, 1 is Upright
+  Int_t                  fOrientation; //Orientation o detector, 0 is 2km horizontal, 1 is Upright
 
   // Could make a TClonesArray of PMTs but let's keep it simple
   //   since the arrays just won't be that large
@@ -86,16 +83,6 @@ public:
   void  SetWCPMTRadius(Float_t f) {fWCPMTRadius = f;}
   void  SetWCOffset(Float_t x, Float_t y, Float_t z) 
            {fWCOffset[0]=x; fWCOffset[1]=y; fWCOffset[2] = z;}
-  void  SetWCXRotation(Float_t x, Float_t y, Float_t z) 
-           {fWCXRotation[0]=x; fWCXRotation[1]=y; fWCXRotation[2] = z;}
-  void  SetWCYRotation(Float_t x, Float_t y, Float_t z) 
-           {fWCYRotation[0]=x; fWCYRotation[1]=y; fWCYRotation[2] = z;}
-  void  SetWCZRotation(Float_t x, Float_t y, Float_t z) 
-           {fWCZRotation[0]=x; fWCZRotation[1]=y; fWCZRotation[2] = z;}
-
-
-
-
 
   void  SetPMT(Int_t i, Int_t tubeno, Int_t cyl_loc, Float_t rot[3], Float_t pos[3], bool expand=true);
   void  SetOrientation(Int_t o) {fOrientation = o;}
@@ -109,10 +96,6 @@ public:
   Int_t GetWCNumPMT() const {return fWCNumPMT;}
   Float_t GetWCPMTRadius() const {return fWCPMTRadius;}
   Float_t GetWCOffset(Int_t i) const {return (i<3) ? fWCOffset[i] : 0.;}
-  Float_t GetWCXRotation(Int_t i) const {return (i<3) ? fWCXRotation[i] : 0.;}
-  Float_t GetWCYRotation(Int_t i) const {return (i<3) ? fWCYRotation[i] : 0.;}
-  Float_t GetWCZRotation(Int_t i) const {return (i<3) ? fWCZRotation[i] : 0.;}
-
    
   Int_t GetOrientation() { return fOrientation; }
   //WCSimRootPMT GetPMT(Int_t i){return *(new WCSimRootPMT());}

--- a/include/WCSimRunAction.hh
+++ b/include/WCSimRunAction.hh
@@ -51,7 +51,6 @@ public:
 
   NRooTrackerVtx* GetRootrackerVertex();
   void FillRootrackerVertexTree() { fRooTrackerOutputTree->Fill();}
-  void FillSettingsTree() { fSettingsOutputTree->Fill();}
   void ClearRootrackerVertexArray() { 
       fVertices->Clear(); 
       fNVtx = 0;
@@ -77,6 +76,11 @@ private:
   int fNVtx;
   bool SaveRooTracker;
   TTree* fSettingsOutputTree;
+  TTree* fSettingsInputTree;
+
+  float WCXRotation[3];
+  float WCYRotation[3];
+  float WCZRotation[3];
 
   WCSimRunActionMessenger* messenger;
   int ntuples;  // 1 for ntuples to be written

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -736,19 +736,20 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
   
   TTree* tree = GetRunAction()->GetTree();
   tree->Fill();
+
+  // Check we are supposed to be saving the NEUT vertex and that the generator was given a NEUT vector file to process
+  // If there is no NEUT vector file an empty NEUT vertex will be written to the output file
+  if(GetRunAction()->GetSaveRooTracker() && generatorAction->IsUsingRootrackerEvtGenerator()){
+      GetRunAction()->ClearRootrackerVertexArray();
+      generatorAction->CopyRootrackerVertex(GetRunAction()->GetRootrackerVertex());
+      GetRunAction()->FillRootrackerVertexTree();
+  }
+
   TFile* hfile = tree->GetCurrentFile();
   // MF : overwrite the trees -- otherwise we have as many copies of the tree
   // as we have events. All the intermediate copies are incomplete, only the
   // last one is useful --> huge waste of disk space.
   hfile->Write("",TObject::kOverwrite);
-
-  // Check we are supposed to be saving the NEUT vertex and that the generator was given a NEUT vector file to process
-  // If there is no NEUT vector file an empty NEUT vertex will be written to the output file
-  if(GetRunAction()->GetSaveRooTracker() && generatorAction->IsUsingRootrackerEvtGenerator()){
-      generatorAction->CopyRootrackerVertex(GetRunAction()->GetRootrackerVertex());
-      GetRunAction()->FillRootrackerVertexTree();
-      GetRunAction()->ClearRootrackerVertexArray();
-  }
   
   // M Fechner : reinitialize the super event after the writing is over
   wcsimrootsuperevent->ReInitialize();

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -296,13 +296,16 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
         yDir=fTmpRootrackerVtx->StdHepP4[0][1];
         zDir=fTmpRootrackerVtx->StdHepP4[0][2];
 
-        double momentum=sqrt(pow(xDir,2)+pow(yDir,2)+pow(zDir,2))*GeV;
+        double momentumGeV=sqrt((xDir*xDir)+(yDir*yDir)+(zDir*zDir))*GeV;
+        double momentum=sqrt((xDir*xDir)+(yDir*yDir)+(zDir*zDir));
 
         G4ThreeVector vtx = G4ThreeVector(xPos*m, yPos*m, zPos*m);
         G4ThreeVector dir = G4ThreeVector(-xDir, -yDir, -zDir);
 
+        dir = dir*(momentumGeV/momentum);
+
         particleGun->SetParticleDefinition(particleTable->FindParticle(fTmpRootrackerVtx->StdHepPdgTemp[0]));
-        particleGun->SetParticleMomentum(momentum);
+        particleGun->SetParticleMomentum(momentumGeV);
         particleGun->SetParticlePosition(vtx);
         particleGun->SetParticleMomentumDirection(dir);
         // Will want to include some beam time structure at some point, but not needed at the moment since we only simulate 1 interaction per events
@@ -319,10 +322,18 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
             yDir=fTmpRootrackerVtx->StdHepP4[i][1];
             zDir=fTmpRootrackerVtx->StdHepP4[i][2];
 
-            double momentum=sqrt(pow(xDir,2)+pow(yDir,2)+pow(zDir,2))*GeV;
+            momentumGeV=sqrt((xDir*xDir)+(yDir*yDir)+(zDir*zDir))*GeV;
+            momentum=sqrt((xDir*xDir)+(yDir*yDir)+(zDir*zDir));
 
-            G4ThreeVector vtx = G4ThreeVector(xPos*m, yPos*m, zPos*m);
-            G4ThreeVector dir = G4ThreeVector(xDir, yDir, zDir);
+            vtx.setX(xPos*m);
+            vtx.setY(yPos*m);
+            vtx.setZ(zPos*m);
+
+            dir.setX(xDir);
+            dir.setY(yDir);
+            dir.setZ(zDir);
+
+            dir = dir*(momentumGeV/momentum);
 
             particleGun->SetParticleDefinition(particleTable->FindParticle(fTmpRootrackerVtx->StdHepPdgTemp[i]));
             particleGun->SetParticleMomentum(momentum);


### PR DESCRIPTION
Move the rotation information into the nuPRISM settings tree, to maintain backwards compatibility of WCSim and fiTQun
