### PR TITLE
PMT saturation

### DIFF
--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -120,6 +120,13 @@ public:
   void   SetPMT_QE_Method(G4int choice){PMT_QE_Method = choice;}
   void   SetPMT_Coll_Eff(G4int choice){PMT_Coll_Eff = choice;}
 
+  void SetDoSaturation(G4bool choice)      {DoSaturation=choice;}
+  void SetSaturationMean(G4double choice)  {SaturationMean=choice;}
+  void SetSaturationSigma(G4double choice) {SaturationSigma=choice;}
+  G4bool   GetDoSaturation()    {return DoSaturation;}
+  G4double GetSaturationMean()  {return SaturationMean;}
+  G4double GetSaturationSigma() {return SaturationSigma;}
+
   //Partition Length
   void SetwaterTank_Length(G4double length){waterTank_Length = length;}
   void SetWaterTubeLength(G4double length){WCLength = length;}
@@ -264,6 +271,10 @@ private:
   typedef std::pair<G4double, G4double> PMTKey_t;
   typedef std::map<PMTKey_t, G4LogicalVolume*> PMTMap_t;
   static PMTMap_t PMTLogicalVolumes;
+
+  G4bool DoSaturation;
+  G4double SaturationMean;
+  G4double SaturationSigma;
 
   // WC geometry parameters
 

--- a/include/WCSimDetectorMessenger.hh
+++ b/include/WCSimDetectorMessenger.hh
@@ -38,6 +38,10 @@ class WCSimDetectorMessenger: public G4UImessenger
   G4UIcmdWithAString* PMTCollEff;
   G4UIcmdWithADoubleAndUnit* waterTank_Length;
 
+  G4UIcmdWithABool* PMTSaturation;
+  G4UIcmdWithADouble* PMTSaturationMean;
+  G4UIcmdWithADouble* PMTSaturationSigma;
+
 
   G4UIcmdWithAString* tubeCmd;
   G4UIcmdWithAString* distortionCmd;

--- a/novis.mac
+++ b/novis.mac
@@ -103,6 +103,14 @@
 #/DarkRate/SetConvert 1.120 #For HPDs
 #/DarkRate/SetConvert 1.126 #For Box and Line PMTs
 
+# PMT Saturation options.
+# Random gaussian for the saturation point per PMT per event (similar to SKDetsim method).
+# Commands are optional; defaults are off, mean = 250.0 pe, 1-sigma-width = 10.0 pe.
+#/WCSim/PMTSaturation/DoSaturation false
+#/WCSim/PMTSaturation/SaturationMean 250.0
+#/WCSim/PMTSaturation/SaturationSigma 10.0
+
+
 #/gun/particle mu- 
 #/gun/particle pi0
 #/gun/energy 500 MeV

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -4,7 +4,9 @@
 #include "G4UIdirectory.hh"
 #include "G4UIcommand.hh"
 #include "G4UIparameter.hh"
+#include "G4UIcmdWithABool.hh"
 #include "G4UIcmdWithAString.hh"
+#include "G4UIcmdWithADouble.hh"
 #include "G4UIcmdWithADoubleAndUnit.hh"
 
 WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimDet)
@@ -93,6 +95,23 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
   PMTCollEff->AvailableForStates(G4State_PreInit, G4State_Idle);
 
 
+  // PMT saturation commands. Currently a gaussian model (saturation off/on, mean, sigma)
+  PMTSaturation = new G4UIcmdWithABool("/WCSim/PMTSaturation/DoSaturation",this);
+  PMTSaturation->SetGuidance("Turn on PMT saturation (boolean, default is false).");
+  PMTSaturation->SetParameterName("DoSaturation", true);
+  PMTSaturation->SetDefaultValue(false);
+
+  PMTSaturationMean = new G4UIcmdWithADouble("/WCSim/PMTSaturation/SaturationMean", this);
+  PMTSaturationMean->SetGuidance("The mean value where PMT hits are saturated (double, default is 250.0).");
+  PMTSaturationMean->SetParameterName("SaturationMean", true);
+  PMTSaturationMean->SetDefaultValue(250.);
+
+  PMTSaturationSigma = new G4UIcmdWithADouble("/WCSim/PMTSaturation/SaturationSigma", this);
+  PMTSaturationSigma->SetGuidance("The 1-sigma gaussian width (double, default is 10.0).");
+  PMTSaturationSigma->SetParameterName("SaturationSigma", true);
+  PMTSaturationSigma->SetDefaultValue(10.);
+
+
   waterTank_Length = new G4UIcmdWithADoubleAndUnit("/WCSim/HyperK/waterTank_Length", this);
   waterTank_Length->SetGuidance("Set the Length of Hyper-K detector (unit: mm cm m).");
   waterTank_Length->SetParameterName("waterTank_length", true);
@@ -162,6 +181,10 @@ WCSimDetectorMessenger::~WCSimDetectorMessenger()
   delete PMTQEMethod;
   delete PMTCollEff;
   delete waterTank_Length;
+
+  delete PMTSaturation;
+  delete PMTSaturationMean;
+  delete PMTSaturationSigma;
 
   delete SetDetectorDiameter;
   delete SetDetectorHeight;
@@ -259,6 +282,13 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 	  }
 	  G4cout << G4endl;
 	}
+
+    else if (command == PMTSaturation)
+        WCSimDetector->SetDoSaturation( PMTSaturation->GetNewBoolValue(newValue) );
+    else if (command == PMTSaturationMean)
+        WCSimDetector->SetSaturationMean( PMTSaturationMean->GetNewDoubleValue(newValue) );
+    else if (command == PMTSaturationSigma)
+        WCSimDetector->SetSaturationSigma( PMTSaturationMean->GetNewDoubleValue(newValue) );
 	
 	if (command == waterTank_Length){
 	bool isHyperK = WCSimDetector->GetIsHyperK();

--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -406,6 +406,13 @@ void WCSimWCDigitizer::DigitizeGate(WCSimWCDigitsCollection* WCHCPMT,G4int G)
       //check if hits in PMT are above threshold
       WCSimWCDigitizer::Threshold(peSmeared,iflag);
       peSmeared *= efficiency; // MC tuning correction
+
+
+      // PMT saturation. Simple gaussian model for random saturation point.
+      if (myDetector->GetDoSaturation() == true) {
+        double saturation_level = G4RandGauss::shoot(myDetector->GetSaturationMean(), myDetector->GetSaturationSigma() );
+        if (peSmeared > saturation_level) peSmeared = saturation_level;
+      }
     
    
     


### PR DESCRIPTION
Implementation of PMT saturation.

Just a Gaussian method, with default parameters taken from SKDetsim (but implemented in a less discontinuous way).

Turned off by default - includes appropriate macro commands for usage (see novis.mac).

![saturation](https://cloud.githubusercontent.com/assets/11435189/7407392/7b9a9eb0-ef4c-11e4-9321-34680c587dfa.png)
