### PR TITLE
Change nuPRISM WCSim so that it exits cleanly once we finish processing a RooTracker file

### DIFF
--- a/include/WCSimPrimaryGeneratorAction.hh
+++ b/include/WCSimPrimaryGeneratorAction.hh
@@ -29,6 +29,7 @@ class WCSimPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
         void SetupBranchAddresses(NRooTrackerVtx* nrootrackervtx);
         void OpenRootrackerFile(G4String fileName);
         void CopyRootrackerVertex(NRooTrackerVtx* nrootrackervtx);
+        bool GetIsRooTrackerFileFinished(){return !fEvNum<fNEntries;}
 
         // Normal gun setting calls these functions to fill jhfNtuple and Root tree
         void SetVtx(G4ThreeVector i)     { vtx = i; };
@@ -58,6 +59,7 @@ class WCSimPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
         G4double GetXDir() {return xDir;};
         G4double GetYDir() {return yDir;};
         G4double GetZDir() {return zDir;};
+
 
     private:
         WCSimDetectorConstruction*      myDetector;

--- a/include/WCSimPrimaryGeneratorAction.hh
+++ b/include/WCSimPrimaryGeneratorAction.hh
@@ -29,7 +29,7 @@ class WCSimPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
         void SetupBranchAddresses(NRooTrackerVtx* nrootrackervtx);
         void OpenRootrackerFile(G4String fileName);
         void CopyRootrackerVertex(NRooTrackerVtx* nrootrackervtx);
-        bool GetIsRooTrackerFileFinished(){return !fEvNum<fNEntries;}
+        bool GetIsRooTrackerFileFinished(){return (fEvNum==fNEntries);}
 
         // Normal gun setting calls these functions to fill jhfNtuple and Root tree
         void SetVtx(G4ThreeVector i)     { vtx = i; };

--- a/include/WCSimRunAction.hh
+++ b/include/WCSimRunAction.hh
@@ -55,6 +55,7 @@ public:
       fVertices->Clear(); 
       fNVtx = 0;
   }
+  const G4Run* GetG4Run(){return fG4Run;}
 
 private:
   // MFechner : set by the messenger
@@ -84,6 +85,8 @@ private:
 
   WCSimRunActionMessenger* messenger;
   int ntuples;  // 1 for ntuples to be written
+
+  const G4Run* fG4Run;
 };
 
 #endif

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -73,7 +73,12 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
 
   G4int n_trajectories = 0;
   if (trajectoryContainer) n_trajectories = trajectoryContainer->entries();
-  
+
+  if(generatorAction->GetIsRooTrackerFileFinished()){
+      GetRunAction()->EndOfRunAction(GetRunAction()->GetG4Run());
+      exit(0);
+  }
+
   // ----------------------------------------------------------------------
   //  Get Event Information
   // ----------------------------------------------------------------------

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -74,7 +74,7 @@ WCSimPrimaryGeneratorAction::WCSimPrimaryGeneratorAction(
 
     fEvNum = 0;
     fInputRootrackerFile = NULL;
-    fNEntries = 0;
+    fNEntries = 1;
 }
 
 WCSimPrimaryGeneratorAction::~WCSimPrimaryGeneratorAction()

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -46,6 +46,8 @@ WCSimRunAction::~WCSimRunAction()
 void WCSimRunAction::BeginOfRunAction(const G4Run* aRun)
 {
 
+  fG4Run = aRun;
+
   fSettingsOutputTree = NULL;
   fSettingsInputTree = NULL;
   for(int i = 0; i < 3; ++i){
@@ -256,6 +258,7 @@ void WCSimRunAction::FillGeoTree(){
 }
 
 NRooTrackerVtx* WCSimRunAction::GetRootrackerVertex(){
+
   NRooTrackerVtx* currRootrackerVtx = new((*fVertices)[fNVtx])NRooTrackerVtx();
   fNVtx += 1;
   return currRootrackerVtx;


### PR DESCRIPTION
Change RunAction to hold a pointer to the G4Run

Change PrimaryGeneratorAction to have a method to determine if the end of the RooTracker file has been reached

Change EventAction so that if the end of the RooTracker file has been reached we close the WCSim output file and exit with the minimum of errors