### PR TITLE
Add features for Gadolinium neutron capture

### DIFF
--- a/WCSim.mac
+++ b/WCSim.mac
@@ -27,7 +27,8 @@
 ## OR for single mPMT mode or updating mPMT parameters:
 #/control/execute macros/mPMT_nuPrism1.mac         ## mPMT options: mPMT_nuPrism1.mac and 2.mac
 
-# Set Gadolinium doping
+# Set Gadolinium doping (concentration is in percent)
+/WCSim/DopingConcentration 0.1
 /WCSim/DopedWater true
 
 #Added for the PMT QE option 08/17/10 (XQ)

--- a/WCSim.mac
+++ b/WCSim.mac
@@ -27,6 +27,8 @@
 ## OR for single mPMT mode or updating mPMT parameters:
 #/control/execute macros/mPMT_nuPrism1.mac         ## mPMT options: mPMT_nuPrism1.mac and 2.mac
 
+# Set Gadolinium doping
+/WCSim/DopedWater true
 
 #Added for the PMT QE option 08/17/10 (XQ)
 # 1. Stacking only mean when the photon is generated

--- a/WCSim.mac
+++ b/WCSim.mac
@@ -19,17 +19,19 @@
 /WCSim/nuPRISM/SetDetectorVerticalPosition -10. m
 #Set diameter of inner detector
 /WCSim/nuPRISM/SetDetectorDiameter 6. m
+# Set Gadolinium doping (concentration is in percent)
+#/WCSim/DopingConcentration 0.1
+/WCSim/DopedWater false
 /WCSim/Construct
 
 #Use mPMTs settings (uncomment/delete the above)
 #/WCSim/WCgeom nuPRISM_mPMT
+# Set Gadolinium doping (concentration is in percent)
+#/WCSim/DopingConcentration 0.1
+#/WCSim/DopedWater false
 #/WCSim/Construct
 ## OR for single mPMT mode or updating mPMT parameters:
 #/control/execute macros/mPMT_nuPrism1.mac         ## mPMT options: mPMT_nuPrism1.mac and 2.mac
-
-# Set Gadolinium doping (concentration is in percent)
-/WCSim/DopingConcentration 0.1
-/WCSim/DopedWater true
 
 #Added for the PMT QE option 08/17/10 (XQ)
 # 1. Stacking only mean when the photon is generated

--- a/include/GdCaptureGammas.hh
+++ b/include/GdCaptureGammas.hh
@@ -1,0 +1,51 @@
+
+///////////////////////////////////////////////////////////////////////////////
+//                   Spectrum of radiative neutron capture by Gadolinium           
+//                                    version 1.0.0                                
+//                                    (Sep.09.2005)                               
+                            
+//                Author : karim.zbiri@subatech.in2p3.fr                  
+
+//This file contains the gammas spectrum produced in radiative capture of 
+//neutrons by gadolinium.
+//This work is adapted from earlier work in geant3 for chooz 1.
+
+//First version by Karim Zbiri, April, 2005
+///////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef GdCaptureGammas_hh
+#define GdCaptureGammas_hh
+
+#include "G4ReactionProductVector.hh"
+#include <vector>
+
+using namespace std;
+
+class GdCaptureGammas
+{
+ public:
+  
+  GdCaptureGammas();
+  ~GdCaptureGammas();
+  G4ReactionProductVector *GetGammas(G4int isotopeA);
+  vector<double> Initialize(G4int isotopeA);
+  vector<double> CapGad155();
+  vector<double> CapGad157();
+  vector<double> casca1Gd155();
+  vector<double> casca2Gd155();
+  vector<double> casca1Gd157();
+  vector<double> casca2Gd157();
+  vector<double> casca3Gd157();
+  vector<double> continuum();
+  double cumule(int );
+  void intc();
+  
+  
+ public:
+  double Elevel;
+  double  xint[4][750];
+ 
+};
+#endif

--- a/include/GdNeutronHPCapture.hh
+++ b/include/GdNeutronHPCapture.hh
@@ -1,0 +1,48 @@
+
+
+///////////////////////////////////////////////////////////////////////////////
+//                   Spectrum of radiative neutron capture by Gadolinium            
+//                                    version 1.0.0                                
+//                                    (Sep.09.2005)                               
+                            
+//Modified class from original G4NeutronHPCapture class to include 
+//the gammas spectrum of radiative neutron capture by Gadolinium.
+
+// Karim Zbiri, April, 2005
+///////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef GdNeutronHPCapture_h
+#define GdNeutronHPCapture_h 1
+
+#include "globals.hh"
+#include "G4NeutronHPChannel.hh"
+#include "G4HadronicInteraction.hh"
+
+class GdNeutronHPCapture : public G4HadronicInteraction
+{
+  public: 
+  
+  GdNeutronHPCapture();
+
+  ~GdNeutronHPCapture();
+
+  G4HadFinalState * ApplyYourself(const G4HadProjectile& aTrack, G4Nucleus& aTargetNucleus);
+
+    void BuildPhysicsTable(const G4ParticleDefinition&);
+    
+  private:
+  
+  G4double * xSec;
+  //G4NeutronHPChannel * theCapture;
+      std::vector<G4NeutronHPChannel*>* theCapture;
+  G4String dirName;
+  G4int numEle;
+  G4int it;
+  // G4String nomel;
+
+  G4HadFinalState theResult;
+};
+
+#endif

--- a/include/GdNeutronHPCaptureFS.hh
+++ b/include/GdNeutronHPCaptureFS.hh
@@ -1,0 +1,74 @@
+
+
+///////////////////////////////////////////////////////////////////////////////
+//                    Spectrum of radiative neutron capture by Gadolinium            
+//                                    version 1.0.0                                
+//                                    (Sep.09.2005)                               
+                            
+//                Author : karim.zbiri@subatech.in2p3.fr                  
+
+//Modified class from original G4NeutronHPCaptureFS class to deexcite and
+//add correctly the secondary to the hadronic final state
+
+// Karim Zbiri, Aug, 2005
+///////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef GdNeutronHPCaptureFS_h
+#define GdNeutronHPCaptureFS_h 1
+
+#include "globals.hh"
+#include "G4HadProjectile.hh"
+#include "G4HadFinalState.hh"
+#include "G4NeutronHPFinalState.hh"
+#include "G4ReactionProductVector.hh"
+#include "G4NeutronHPNames.hh"
+#include "G4NeutronHPPhotonDist.hh"
+#include "G4Nucleus.hh"
+#include "G4Fragment.hh"
+
+#include "GdCaptureGammas.hh"
+
+class GdNeutronHPCaptureFS : public G4NeutronHPFinalState
+{
+  public:
+  
+  GdNeutronHPCaptureFS()
+  {
+    hasXsec = false; 
+    targetMass = 0;
+  }
+  
+  ~GdNeutronHPCaptureFS()
+  {
+  }
+  
+  void   UpdateNucleus( const G4Fragment* , G4double );
+  void Init (G4double A, G4double Z, G4int M, G4String & dirName, G4String & aFSType);
+  G4HadFinalState * ApplyYourself(const G4HadProjectile & theTrack);
+  G4NeutronHPFinalState * New() 
+  {
+   GdNeutronHPCaptureFS * theNew = new GdNeutronHPCaptureFS;
+   return theNew;
+  }
+  
+  private:
+
+  G4Fragment * nucleus;
+
+  G4DynamicParticle * theTwo ;
+  G4ReactionProduct theTarget; 
+  G4Nucleus aNucleus;
+  G4ReactionProduct theNeutron;
+
+  G4double targetMass;
+  
+  G4NeutronHPPhotonDist theFinalStatePhotons;
+  GdCaptureGammas       theFinalgammas;
+  G4NeutronHPNames theNames;
+  
+  G4double theCurrentA;
+  G4double theCurrentZ;
+};
+#endif

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -295,6 +295,8 @@ public:
   G4double GetPMTCoverage() {return WCPMTPercentCoverage;}
 
     void SetDopedWater(G4bool dopedWater){WCAddGd = dopedWater; }
+    G4bool GetIsGadoliniumConcentrationSet() {return isGdConcentrationSet;}
+    void SetGadoliniumConcentration(G4double percent);
 
   std::vector<WCSimPmtInfo*>* Get_Pmts() {return &fpmts;}
 
@@ -381,6 +383,7 @@ private:
   G4double capAssemblyHeight;
 
   G4bool WCAddGd;
+  G4bool isGdConcentrationSet;
 
   // Code for traversing the geometry and assigning tubeIDs.
 

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -294,6 +294,8 @@ public:
   }
   G4double GetPMTCoverage() {return WCPMTPercentCoverage;}
 
+    void SetDopedWater(G4bool dopedWater){WCAddGd = dopedWater; }
+
   std::vector<WCSimPmtInfo*>* Get_Pmts() {return &fpmts;}
 
   void   SetDetectorHeight(G4double height) {

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -295,8 +295,7 @@ public:
   G4double GetPMTCoverage() {return WCPMTPercentCoverage;}
 
     void SetDopedWater(G4bool dopedWater){WCAddGd = dopedWater; }
-    G4bool GetIsGadoliniumConcentrationSet() {return isGdConcentrationSet;}
-    void SetGadoliniumConcentration(G4double percent);
+    void AddDopedWater(G4double percentGd = 0.1);
 
   std::vector<WCSimPmtInfo*>* Get_Pmts() {return &fpmts;}
 
@@ -383,7 +382,6 @@ private:
   G4double capAssemblyHeight;
 
   G4bool WCAddGd;
-  G4bool isGdConcentrationSet;
 
   // Code for traversing the geometry and assigning tubeIDs.
 

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -147,7 +147,11 @@ public:
   // Related to Pi0 analysis
   G4bool SavePi0Info()              {return pi0Info_isSaved;}
   void   SavePi0Info(G4bool choice) {pi0Info_isSaved=choice;}
-  
+
+  // Related to neutron capture analysis
+  G4bool SaveCaptureInfo()              {return captureInfo_isSaved;}
+  void   SaveCaptureInfo(G4bool choice) {captureInfo_isSaved=choice;}
+
   void   SetPMT_QE_Method(G4int choice){PMT_QE_Method = choice;}
   void   SetPMT_Coll_Eff(G4int choice){PMT_Coll_Eff = choice;}
   void   SetVis_Choice(G4String choice){Vis_Choice = choice;}
@@ -411,7 +415,8 @@ private:
   // toggle between lArD readout types
   // toggle between MRDScint and MRDk2k
 
-  G4bool pi0Info_isSaved;
+    G4bool pi0Info_isSaved;
+    G4bool captureInfo_isSaved;
 
 
   // XQ 08/17/10

--- a/include/WCSimDetectorMessenger.hh
+++ b/include/WCSimDetectorMessenger.hh
@@ -38,6 +38,7 @@ class WCSimDetectorMessenger: public G4UImessenger
   G4UIcmdWithAString* PMTGeomDetails;
   G4UIcmdWithAString* PMTSize;
   G4UIcmdWithAString* SavePi0;
+  G4UIcmdWithAString* SaveCapture;
   G4UIcmdWithAString* PMTQEMethod;
   G4UIcmdWithAString* PMTCollEff;
   G4UIcmdWithADoubleAndUnit* waterTank_Length;

--- a/include/WCSimDetectorMessenger.hh
+++ b/include/WCSimDetectorMessenger.hh
@@ -41,6 +41,7 @@ class WCSimDetectorMessenger: public G4UImessenger
   G4UIcmdWithAString* SaveCapture;
   G4UIcmdWithAString* PMTQEMethod;
   G4UIcmdWithAString* PMTCollEff;
+  G4UIcmdWithABool* DopedWater;
   G4UIcmdWithADoubleAndUnit* waterTank_Length;
 
   G4UIdirectory*             mPMTDir;

--- a/include/WCSimDetectorMessenger.hh
+++ b/include/WCSimDetectorMessenger.hh
@@ -42,6 +42,7 @@ class WCSimDetectorMessenger: public G4UImessenger
   G4UIcmdWithAString* PMTQEMethod;
   G4UIcmdWithAString* PMTCollEff;
   G4UIcmdWithABool* DopedWater;
+  G4UIcmdWithADouble* DopingConcentration;
   G4UIcmdWithADoubleAndUnit* waterTank_Length;
 
   G4UIdirectory*             mPMTDir;

--- a/include/WCSimPhysicsListFactory.hh
+++ b/include/WCSimPhysicsListFactory.hh
@@ -19,6 +19,7 @@ class WCSimPhysicsListFactory : public G4VModularPhysicsList
     ~WCSimPhysicsListFactory();
 
     void SetList(G4String newvalue);  // called by messenger
+    void SetnCaptModel(G4String newvalue);  // called by messenger
     void InitializeList();
 
     //G4String GetPhysicsListName() {return PhysicsListName;}
@@ -33,6 +34,8 @@ class WCSimPhysicsListFactory : public G4VModularPhysicsList
 
     G4String PhysicsListName;
     G4String ValidListsString;
+    
+    G4String nCaptModelChoice;
 
     WCSimPhysicsListFactoryMessenger* PhysicsMessenger;
     G4PhysListFactory* factory;

--- a/include/WCSimPhysicsListFactoryMessenger.hh
+++ b/include/WCSimPhysicsListFactoryMessenger.hh
@@ -23,6 +23,7 @@ private:
 
   G4UIdirectory*      WCSimDir;
   G4UIcmdWithAString* physListCmd;
+  G4UIcmdWithAString* nCaptureModelCmd;
 
 };
 

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -187,30 +187,100 @@ public:
 //////////////////////////////////////////////////////////////////////////
 
 class WCSimRootPi0 : public TObject {
-  // this is a class used specifically for Pi0 events
+    // this is a class used specifically for Pi0 events
 
 private:
-  Float_t fPi0Vtx[3];
-  Int_t   fGammaID[2];
-  Float_t fGammaE[2];
-  Float_t fGammaVtx[2][3];
+    Float_t fPi0Vtx[3];
+    Int_t   fGammaID[2];
+    Float_t fGammaE[2];
+    Float_t fGammaVtx[2][3];
 
 public:
-  WCSimRootPi0() {}
+    WCSimRootPi0() {}
 
-  virtual ~WCSimRootPi0() {}
+    virtual ~WCSimRootPi0() {}
 
-  void Set(Float_t pi0Vtx[3],
-	   Int_t   gammaID[2],
-	   Float_t gammaE[2],
-	   Float_t gammaVtx[2][3]);
+    void Set(Float_t pi0Vtx[3],
+	     Int_t   gammaID[2],
+	     Float_t gammaE[2],
+	     Float_t gammaVtx[2][3]);
 
-  Float_t  GetPi0Vtx(int i)           const { return (i<3) ? fPi0Vtx[i]: 0;}
-  Int_t    GetGammaID(int i)          const { return (i<2) ? fGammaID[i]: 0;}
-  Float_t  GetGammaE(int i)           const { return (i<2) ? fGammaE[i]: 0;}
-  Float_t  GetGammaVtx(int i, int j)  const { return fGammaVtx[i][j];}
+    Float_t  GetPi0Vtx(int i)           const { return (i<3) ? fPi0Vtx[i]: 0;}
+    Int_t    GetGammaID(int i)          const { return (i<2) ? fGammaID[i]: 0;}
+    Float_t  GetGammaE(int i)           const { return (i<2) ? fGammaE[i]: 0;}
+    Float_t  GetGammaVtx(int i, int j)  const { return fGammaVtx[i][j];}
 
-  ClassDef(WCSimRootPi0,1)
+ClassDef(WCSimRootPi0,1)
+};
+
+//////////////////////////////////////////////////////////////////////////
+
+class WCSimRootCaptureGamma : public TObject {
+
+private:
+    Int_t   fID;
+    Float_t fEnergy;
+    Float_t fDir[3];
+
+public:
+    WCSimRootCaptureGamma() {}
+    WCSimRootCaptureGamma(Int_t id,
+                          Float_t energy,
+                          Float_t dir[3]
+    );
+
+    virtual ~WCSimRootCaptureGamma() {}
+
+    Int_t    GetID()           const { return fID;}
+    Float_t  GetE()            const { return fEnergy;}
+    Float_t  GetDir(int i)     const { return (i<3) ? fDir[i]: 0;}
+
+ClassDef(WCSimRootCaptureGamma,1)
+};
+
+//////////////////////////////////////////////////////////////////////////
+
+class WCSimRootCapture : public TObject {
+    // this is a class used specifically for neutron capture events
+
+private:
+    Int_t   	   fCaptureParent;
+    Float_t 	   fCaptureVtx[3];
+    Int_t   	   fNGamma;
+    Float_t 	   fTotalGammaE;
+    Float_t 	   fCaptureT;
+    Int_t          fCaptureNucleus;
+    TClonesArray * fGammas;
+    bool 	   IsZombie;
+
+public:
+    WCSimRootCapture() {
+      fGammas = 0;
+      IsZombie = true;
+    }
+    WCSimRootCapture(Int_t captureParent);
+
+    virtual ~WCSimRootCapture();
+
+    void SetInfo(Float_t captureVtx[3],
+	         Float_t captureT,
+		 Int_t   captureNucleus
+    );
+
+    void AddGamma(Int_t   gammaID,
+		  Float_t gammaE,
+		  Float_t gammaDir[3]
+    );
+
+    Int_t                   GetCaptureParent()   const { return fCaptureParent;}
+    Float_t                 GetCaptureVtx(int i) const { return (i<3) ? fCaptureVtx[i]: 0;}
+    Int_t                   GetNGamma()          const { return fNGamma;}
+    Float_t                 GetTotalGammaE()     const { return fTotalGammaE;}
+    Float_t                 GetCaptureT()        const { return fCaptureT;}
+    Int_t                   GetCaptureNucleus()  const { return fCaptureNucleus;}
+    TClonesArray	   *GetGammas()          const { return fGammas;}
+
+ClassDef(WCSimRootCapture,1)
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -228,6 +298,9 @@ private:
   Int_t                fJp;
 
   WCSimRootPi0        fPi0;                // Pi0 info (default = not used)
+
+  TClonesArray        *fCaptures;            // Neutron capture info (default = not used)
+  Int_t                fNcaptures;             // Number of tracks in the array
 
   Int_t                fNpar;               // Number of particles
   Int_t                fNtrack;             // Number of tracks in the array
@@ -274,14 +347,21 @@ public:
   void          SetNumTubesHit(Int_t i) {fNumTubesHit = i;}
   void          SetSumQ(Float_t x){fSumQ = x;}
   void          SetNumDigitizedTubes(Int_t i) {fNumDigitizedTubes = i;}
-  void          SetPi0Info(Float_t pi0Vtx[3], 
-			   Int_t   gammaID[2], 
+  void          SetPi0Info(Float_t pi0Vtx[3],
+			   Int_t   gammaID[2],
 			   Float_t gammaE[2],
 			   Float_t gammaVtx[2][3]);
+  void          SetCaptureParticle(Int_t parent,
+                                   Int_t ipnu,
+                                   Float_t time,
+                                   Float_t vtx[3],
+                                   Float_t dir[3],
+                                   Float_t energy,
+                                   Int_t id);
 
 
-  WCSimRootEventHeader *GetHeader()               {return &fEvtHdr; }
-  WCSimRootPi0       *GetPi0Info()                 {return &fPi0; }
+  WCSimRootEventHeader *GetHeader()                 {return &fEvtHdr; }
+  WCSimRootPi0       *GetPi0Info()                  {return &fPi0; }
   Int_t               GetMode()               const {return fMode;}
   Int_t               GetVtxvol()             const {return fVtxvol;}
   Float_t             GetVtx(Int_t i=0)             {return (i<3) ? fVtx[i]: 0;}
@@ -292,12 +372,13 @@ public:
   Int_t               GetNumTubesHit()        const {return fNumTubesHit;}
   Int_t               GetNumDigiTubesHit()    const {return fNumDigitizedTubes;}
   Int_t               GetNtrack()             const {return fNtrack; }
+  Int_t               GetNcaptures()          const {return fNcaptures; }
   Int_t               GetNcherenkovhits()     const {return fNcherenkovhits; }
   Int_t               GetNcherenkovhittimes() const {return fNcherenkovhittimes;}
   Int_t               GetNcherenkovdigihits() const {return fNcherenkovdigihits;}
   Float_t             GetSumQ()               const { return fSumQ;}
   TriggerType_t       GetTriggerType()        const { return fTriggerType;}
-  std::vector<Float_t> GetTriggerInfo()        const { return fTriggerInfo;}
+  std::vector<Float_t> GetTriggerInfo()       const { return fTriggerInfo;}
 
   WCSimRootTrack         *AddTrack(Int_t ipnu, 
 				   Int_t flag, 
@@ -337,7 +418,10 @@ public:
 
   TClonesArray            *GetCherenkovDigiHits() const {return fCherenkovDigiHits;}
 
-  ClassDef(WCSimRootTrigger,2) //WCSimRootEvent structure
+  TClonesArray	      *GetCaptures() const {return fCaptures;}
+
+
+ClassDef(WCSimRootTrigger,2) //WCSimRootEvent structure
 };
 
 

--- a/include/WCSimRootLinkDef.hh
+++ b/include/WCSimRootLinkDef.hh
@@ -15,6 +15,8 @@
 #pragma link C++ class WCSimRootTrigger+;
 #pragma link C++ class WCSimRootEvent+;
 #pragma link C++ class WCSimRootPi0+;
+#pragma link C++ class WCSimRootCapture+;
+#pragma link C++ class WCSimRootCaptureGamma+;
 #pragma link C++ class WCSimRootGeom+;
 #pragma link C++ class WCSimRootPMT+;
 #pragma link C++ class WCSimPmtInfo+;

--- a/macros/daq.mac
+++ b/macros/daq.mac
@@ -24,11 +24,11 @@
 #options for NDigits-like triggers (defaults are class-specific. Can be overridden here)
 # control the NDigits trigger threshold
 # (note in SKI_SKDETSIM, this is actually the value used for the NHits trigger (NHits != NDigits))
-/DAQ/TriggerNDigits/Threshold 5
+#/DAQ/TriggerNDigits/Threshold 25
 # the trigger counts digits (looking for threshold) in this window (ns)
-/DAQ/TriggerNDigits/Window 50
+#/DAQ/TriggerNDigits/Window 200
 # automatically adjust the NDigits threshold depending on the average noise occupancy during the trigger window
-/DAQ/TriggerNDigits/AdjustForNoise true
+#/DAQ/TriggerNDigits/AdjustForNoise true
 # the digits in which range around the trigger time (ns) should be saved with the event
-/DAQ/TriggerNDigits/PreTriggerWindow  -100
-/DAQ/TriggerNDigits/PostTriggerWindow +150
+#/DAQ/TriggerNDigits/PreTriggerWindow  -400
+#/DAQ/TriggerNDigits/PostTriggerWindow +950

--- a/macros/daq.mac
+++ b/macros/daq.mac
@@ -24,11 +24,11 @@
 #options for NDigits-like triggers (defaults are class-specific. Can be overridden here)
 # control the NDigits trigger threshold
 # (note in SKI_SKDETSIM, this is actually the value used for the NHits trigger (NHits != NDigits))
-#/DAQ/TriggerNDigits/Threshold 25
+/DAQ/TriggerNDigits/Threshold 5
 # the trigger counts digits (looking for threshold) in this window (ns)
-#/DAQ/TriggerNDigits/Window 200
+/DAQ/TriggerNDigits/Window 50
 # automatically adjust the NDigits threshold depending on the average noise occupancy during the trigger window
-#/DAQ/TriggerNDigits/AdjustForNoise true
+/DAQ/TriggerNDigits/AdjustForNoise true
 # the digits in which range around the trigger time (ns) should be saved with the event
-#/DAQ/TriggerNDigits/PreTriggerWindow  -400
-#/DAQ/TriggerNDigits/PostTriggerWindow +950
+/DAQ/TriggerNDigits/PreTriggerWindow  -100
+/DAQ/TriggerNDigits/PostTriggerWindow +150

--- a/macros/jobOptions.mac
+++ b/macros/jobOptions.mac
@@ -12,8 +12,8 @@
 #
 #/WCSim/physics/list QGSP_BIC_HP #preferred for energies below 5 GeV
 #/WCSim/physics/list LBE # preferred for low-background experiments.  
-#/WCSim/physics/list FTFP_BERT # recommended for high energy physics and hadron production up to beam momentum of several tens of GeV/c.
-/WCSim/physics/list FTFP_BERT_HP
-/WCSim/physics/nCapture HP
+/WCSim/physics/list FTFP_BERT # recommended for high energy physics and hadron production up to beam momentum of several tens of GeV/c.
+#/WCSim/physics/list FTFP_BERT_HP
+/WCSim/physics/nCapture Default
 
 

--- a/macros/jobOptions.mac
+++ b/macros/jobOptions.mac
@@ -12,6 +12,8 @@
 #
 #/WCSim/physics/list QGSP_BIC_HP #preferred for energies below 5 GeV
 #/WCSim/physics/list LBE # preferred for low-background experiments.  
-/WCSim/physics/list FTFP_BERT # recommended for high energy physics and hadron production up to beam momentum of several tens of GeV/c.
+#/WCSim/physics/list FTFP_BERT # recommended for high energy physics and hadron production up to beam momentum of several tens of GeV/c.
+/WCSim/physics/list FTFP_BERT_HP
+/WCSim/physics/nCapture HP
 
 

--- a/src/GdCaptureGammas.cc
+++ b/src/GdCaptureGammas.cc
@@ -1,0 +1,263 @@
+
+///////////////////////////////////////////////////////////////////////////////
+//                 Spectrum of radiative neutron capture by Gadolinium            
+//                                    version 1.0.0                                
+//                                    (Sep.09.2005)                               
+                            
+//                Author : karim.zbiri@subatech.in2p3.fr                  
+
+//This file contains the gammas spectrum produced in radiative capture of 
+//neutrons by gadolinium.
+//This work is adapted from earlier work in geant3 for chooz 1.
+
+//First version by Karim Zbiri, April, 2005
+///////////////////////////////////////////////////////////////////////////////
+
+
+#include "GdCaptureGammas.hh"
+#include "Randomize.hh"
+#include <vector>
+#include "G4Gamma.hh"
+using namespace std;
+
+GdCaptureGammas::GdCaptureGammas () {}
+
+GdCaptureGammas::~GdCaptureGammas () {}
+
+G4ReactionProductVector *  GdCaptureGammas::GetGammas(G4int isotopeA) 
+{
+  G4ReactionProductVector * theGammas = new G4ReactionProductVector;
+  vector<double> nrj = Initialize(isotopeA);
+  for(unsigned int i=0; i<nrj.size(); i++)
+    {
+      G4ReactionProduct * theOne = new G4ReactionProduct;
+      theOne->SetDefinition( G4Gamma::Gamma() );
+
+      G4double costheta = 2.*G4UniformRand()-1;
+      G4double theta = acos(costheta);
+      G4double phi = CLHEP::twopi*G4UniformRand();
+      G4double sinth = sin(theta);
+
+      theOne->SetTotalEnergy( nrj[i] );
+      G4ThreeVector temp(nrj[i]*sinth*cos(phi), nrj[i]*sinth*sin(phi),nrj[i]*cos(theta) );
+      theOne->SetMomentum( temp ) ;
+      theGammas->push_back(theOne);  
+    }
+   return theGammas;
+}
+
+vector<double> GdCaptureGammas::Initialize(G4int isotopeA)
+{
+  vector<double> Eg; 
+  //double DefElem = G4UniformRand()*48.80;
+  //if(DefElem < 39.83)
+  if(isotopeA == 157)
+    Eg = CapGad157();
+  else if(isotopeA == 155)
+    Eg = CapGad155();
+  else {
+      G4cerr << "Unexpected Gd isotope A=" << isotopeA << ". Using 157 instead." << G4endl;
+      Eg = CapGad157();
+  }
+
+  return Eg;
+}
+
+vector<double>  GdCaptureGammas::CapGad155()
+{
+  //  gammas from GAD155
+  //                   either 2 gammas
+  //                   either a continuum
+  //                   total energy = 8.46 MeV
+
+   Elevel = 8.46;
+  double Nlevel = G4UniformRand();
+  vector<double> Egammas;
+
+  if(Nlevel > 0.023) Egammas=continuum();
+  else if (Nlevel >= 0.013) Egammas=casca1Gd155();
+  else  Egammas=casca2Gd155();
+
+  return Egammas;
+}
+
+vector<double>  GdCaptureGammas::CapGad157()
+{
+  //  gammas from GAD155
+  //                   either 2 gammas
+  //                   either a continuum
+  //                   total energy = 7.87 MeV
+
+  Elevel = 7.87;
+  double Nlevel = G4UniformRand();
+  vector<double> Egammas;
+
+  if(Nlevel > 0.068) Egammas=continuum();
+  else if(Nlevel < 0.037) Egammas=casca1Gd157(); 
+  else if(Nlevel < 0.05)  Egammas=casca2Gd157(); 
+  else if(Nlevel >= 0.05)  Egammas=casca3Gd157(); 
+
+  return Egammas;
+}
+
+vector<double>  GdCaptureGammas::casca1Gd155()
+{
+  vector<double> energy;
+  energy.push_back(7.33);
+  energy.push_back(1.17);
+  return energy;
+}
+
+vector<double>  GdCaptureGammas::casca2Gd155()
+{
+  vector<double> energy;
+  energy.push_back(6.44);
+  energy.push_back(2.18);
+  return energy;
+}
+
+vector<double>  GdCaptureGammas::casca1Gd157()
+{
+  vector<double> energy;
+  energy.push_back(6.74);
+  energy.push_back(1.11);
+  return energy;
+}
+
+vector<double>  GdCaptureGammas::casca2Gd157()
+{
+  vector<double> energy;
+  energy.push_back(5.62);
+  energy.push_back(2.25);
+  return energy;
+}
+
+vector<double>  GdCaptureGammas::casca3Gd157()
+{
+  vector<double> energy;
+  energy.push_back(5.88);
+  energy.push_back(1.99);
+  return energy;
+}
+
+
+vector<double>  GdCaptureGammas::continuum()
+{
+  // continuum part of gadolinium
+  //cross sections
+  vector<double> energy;
+  const double eps=0.0001,bint=0.01;
+  const int ngadbin=750;
+  float sigfond,sigex1,sigftot,sigcont,sigtot;
+  double dexlevel,auxe,hasard,cint,Eneuve;
+  int isigma;
+  do
+    {      
+  //first excited level and ground level
+      sigfond=pow(Elevel,3); 
+      sigex1=pow(Elevel-1,3);
+      sigftot=sigfond+sigex1; 
+      
+  //continuum
+      auxe=(Elevel-2.)/bint;
+      isigma=int(auxe+eps);
+      sigcont=cumule(isigma);
+      sigtot=sigfond+sigex1+sigcont;      
+      dexlevel=G4UniformRand()*sigtot; 
+      if(dexlevel < sigfond) 
+	{ 
+	  energy.push_back(Elevel); Elevel =0.;
+	  return energy;}
+     if((dexlevel>= sigfond) &&  (dexlevel <= sigftot)) {
+	energy.push_back(Elevel-1);
+	energy.push_back(1);
+	Elevel=0.;
+	return energy;}
+      if(dexlevel > sigftot) 
+	{
+	  hasard=G4UniformRand()*sigcont;
+	  for(int i=0;i<ngadbin;i++)
+	    {
+	      Eneuve=bint*(i+1.)+2.; 
+	      cint=cumule(i+1); 	      
+	      if(cint>hasard) 
+		{
+		  if(Elevel>Eneuve)
+		    {
+		      energy.push_back(Elevel-Eneuve);
+		      Elevel=Eneuve;
+		    }		
+		  if(Elevel<2.) exit(0);
+		  if(Elevel <= 2.01) {energy.push_back(Elevel);Elevel =0.;
+		    return energy;}
+		  break;
+		}
+	      if(i==ngadbin-1) exit(0);
+	    }
+	}     
+    } while(Elevel > 2.01);
+  //energy.push_back(Elevel);
+   return energy;
+}
+
+double  GdCaptureGammas::cumule(int ienerg)
+{  
+//   computes the integrated probability from the threshold
+//                                       to the energy of indice ienerg
+
+//   input  :    IENERG  indice for the energy with NGADBIN intervalles
+//                                             of width BINT
+
+//   output : integrated probabilities cumule
+
+  double norm,A,A2,A4,A6,T1,T2,T3,T4,xi;
+  // const double eps=0.0001;
+  const int ngadbin=750;
+  if(ienerg>ngadbin-1) exit(0);
+  intc();
+  norm=2./(pow(sqrt(37.),8));
+  A=sqrt(37.)*sqrt(Elevel-2.);
+  A2=pow(A,2);
+  A4=pow(A,4);
+  A6=pow(A,6);
+  T1=xint[0][ienerg]*A6; 
+  T2=-3.*xint[1][ienerg]*A4;
+  T3=3.*xint[2][ienerg]*A2;
+  T4=-1.0*xint[3][ienerg]; 
+  xi=T1+T2+T3+T4;
+  return norm*xi;
+} 
+
+void  GdCaptureGammas::intc()
+{
+//   computes the table xint(4,750)
+//                          integration 
+//                          of the function  (X**N) * exp(X)
+
+
+//   output : N=1 comes in XINT(1,75)
+//                 2               2
+//                 3               3
+//                 4               4
+
+  double aux[7],ener,xk;
+  const double ngadbin=750,bint=0.01;
+  for(int i=0;i<ngadbin;i++)
+    {
+      ener=bint*(i+1.)+2.;
+      xk=sqrt(37.)*sqrt(ener-2.);
+      aux[0]=exp(xk)*(xk-1.)+1.;
+      for(int j=1;j<7;j++)
+	{	 
+	  aux[j]=pow(xk,j+1)*exp(xk)-(j+1)*aux[j-1];
+	}
+      xint[0][i]=aux[0];
+      xint[1][i]=aux[2];
+      xint[2][i]=aux[4];
+      xint[3][i]=aux[6];
+    } 
+}
+
+
+
+

--- a/src/GdNeutronHPCapture.cc
+++ b/src/GdNeutronHPCapture.cc
@@ -1,0 +1,191 @@
+
+///////////////////////////////////////////////////////////////////////////////
+//                   Spectrum of radiative neutron capture by Gadolinium            
+//                                    version 1.0.0                                
+//                                    (Sep.09.2005)                               
+                            
+//Modified class from original G4NeutronHPCapture class to include 
+//the gammas spectrum of radiative neutron capture by Gadolinium.
+
+// Karim Zbiri, April, 2005
+///////////////////////////////////////////////////////////////////////////////
+
+
+#include "GdNeutronHPCapture.hh"
+/////////#include "OtherHPCaptureFS.hh"
+//#include "G4NeutronHPCaptureFS2.hh"
+#include "G4NeutronHPDeExGammas.hh"
+#include "G4ParticleTable.hh"
+#include "G4IonTable.hh"
+
+#include "GdNeutronHPCaptureFS.hh"
+
+  GdNeutronHPCapture::GdNeutronHPCapture()
+   :G4HadronicInteraction("NeutronHPCapture")
+  ,theCapture(NULL)
+  ,numEle(0)
+  {
+    SetMinEnergy( 0.0 );
+    SetMaxEnergy( 20.*MeV );
+    /*
+    G4cout << "Capture : start of construction!!!!!!!!"<<G4endl;
+    if(!getenv("G4NEUTRONHPDATA")) 
+       throw G4HadronicException(__FILE__, __LINE__, "Please setenv G4NEUTRONHPDATA to point to the neutron cross-section files.");
+    dirName = getenv("G4NEUTRONHPDATA");
+    G4String tString = "/Capture";
+    dirName = dirName + tString;
+    numEle = G4Element::GetNumberOfElements();
+   G4cout << "+++++++++++++++++++++++++++++++++++++++++++++++++"<<G4endl;
+   //    G4cout <<"Disname="<<dirName<<" numEle="<<numEle<<G4endl;
+  
+    theCapture = new G4NeutronHPChannel[numEle];
+    //    G4cout <<"G4NeutronHPChannel constructed"<<G4endl;
+      G4NeutronHPCaptureFS * theFS = new G4NeutronHPCaptureFS; 
+    //    OtherHPCaptureFS * theFS = new OtherHPCaptureFS; 
+    GdNeutronHPCaptureFS * theGdFS = new GdNeutronHPCaptureFS;
+
+    for (G4int i=0; i<numEle; i++)
+    {
+//      G4cout << "initializing theCapture "<<i<<" "<< numEle<<G4endl;
+      //    if((*(G4Element::GetElementTable()))[i]->GetName()!="Gadolinium")
+      if((*(G4Element::GetElementTable()))[i]->GetZ() != 64)
+	{
+	  theCapture[i].Init((*(G4Element::GetElementTable()))[i], dirName);
+         G4cout<<(*(G4Element::GetElementTable()))[i]->GetName()<<G4endl;
+	 	 theCapture[i].Register(theFS);
+	 //	 theCapture[i].Register(theGdFS);
+	}
+      else {
+      theCapture[i].Init((*(G4Element::GetElementTable()))[i], dirName);
+       G4cout<<(*(G4Element::GetElementTable()))[i]->GetName()<<G4endl;
+        theCapture[i].Register(theGdFS);
+	// theCapture[i].Register(theFS);
+      }
+    }
+    delete theFS;
+    delete theGdFS;*/
+//    G4cout << "-------------------------------------------------"<<G4endl;
+//    G4cout << "Leaving GdNeutronHPCapture::GdNeutronHPCapture"<<G4endl;
+  }
+  
+  GdNeutronHPCapture::~GdNeutronHPCapture()
+  {
+    //delete [] theCapture;
+//    G4cout << "Leaving GdNeutronHPCapture::~GdNeutronHPCapture"<<G4endl;
+     for ( std::vector<G4NeutronHPChannel*>::iterator 
+           ite = (*theCapture).begin() ; ite != (*theCapture).end() ; ite++ )
+     {
+        delete *ite;
+     }
+     (*theCapture).clear();
+  }
+  
+  #include "G4NeutronHPThermalBoost.hh"
+  G4HadFinalState * GdNeutronHPCapture::ApplyYourself(const G4HadProjectile& aTrack, G4Nucleus& aNucleus )
+  {
+    G4NeutronHPManager::GetInstance()->OpenReactionWhiteBoard();
+    if(getenv("NeutronHPCapture")) G4cout <<" ####### GdNeutronHPCapture called"<<G4endl;
+    const G4Material * theMaterial = aTrack.GetMaterial();
+    G4int n = theMaterial->GetNumberOfElements();
+    G4int index = theMaterial->GetElement(0)->GetIndex();
+    if(n!=1)
+    {
+      xSec = new G4double[n];
+      G4double sum=0;
+      G4int i;
+      const G4double * NumAtomsPerVolume = theMaterial->GetVecNbOfAtomsPerVolume();
+      G4double rWeight;    
+      G4NeutronHPThermalBoost aThermalE;
+      for (i=0; i<n; i++)
+      {
+        index = theMaterial->GetElement(i)->GetIndex();
+        rWeight = NumAtomsPerVolume[i];
+          G4cout << theMaterial->GetElement(i)->GetName() << G4endl;
+        xSec[i] = (*(*theCapture)[index]).GetXsec(aThermalE.GetThermalEnergy(aTrack,
+  		                                                     theMaterial->GetElement(i),
+  								     theMaterial->GetTemperature()));
+        xSec[i] *= rWeight;
+        sum+=xSec[i];
+      }
+      G4double random = G4UniformRand();
+      G4double running = 0;
+      for (i=0; i<n; i++)
+      {
+        running += xSec[i];
+        index = theMaterial->GetElement(i)->GetIndex();
+        //if(random<=running/sum) break;
+        if( sum == 0 || random <= running/sum ) break;
+      }
+      if(i==n) i=std::max(0, n-1);
+      delete [] xSec;
+    }
+    //return theCapture[index].ApplyYourself(aTrack);
+    //G4HadFinalState* result = theCapture[index].ApplyYourself(aTrack);
+    G4HadFinalState* result = (*(*theCapture)[index]).ApplyYourself(aTrack);
+
+    //Overwrite target parameters
+    aNucleus.SetParameters(G4NeutronHPManager::GetInstance()->GetReactionWhiteBoard()->GetTargA(),G4NeutronHPManager::GetInstance()->GetReactionWhiteBoard()->GetTargZ());
+    const G4Element* target_element = (*G4Element::GetElementTable())[index];
+    const G4Isotope* target_isotope=NULL;
+    G4int iele = target_element->GetNumberOfIsotopes();
+    for ( G4int j = 0 ; j != iele ; j++ ) {
+      target_isotope=target_element->GetIsotope( j );
+      if ( target_isotope->GetN() == G4NeutronHPManager::GetInstance()->GetReactionWhiteBoard()->GetTargA() ) break;
+    }
+    //G4cout << "Target Material of this reaction is " << theMaterial->GetName() << G4endl;
+    //G4cout << "Target Element of this reaction is " << target_element->GetName() << G4endl;
+    //G4cout << "Target Isotope of this reaction is " << target_isotope->GetName() << G4endl;
+    aNucleus.SetIsotope( target_isotope );
+
+    G4NeutronHPManager::GetInstance()->CloseReactionWhiteBoard();
+    return result;
+  }
+
+void GdNeutronHPCapture::BuildPhysicsTable(const G4ParticleDefinition&)
+{
+
+   if ( !G4Threading::IsWorkerThread() ){
+
+      if ( theCapture == NULL ) theCapture = new std::vector<G4NeutronHPChannel*>;
+
+      if ( numEle == (G4int)G4Element::GetNumberOfElements() ) return;
+
+      if ( theCapture->size() == G4Element::GetNumberOfElements() ) {
+         numEle = G4Element::GetNumberOfElements();
+         return;
+      }
+
+
+      G4cout << "Capture : start of construction!!!!!!!!" << G4endl;
+      if ( !getenv("G4NEUTRONHPDATA") ) 
+          throw G4HadronicException(__FILE__, __LINE__, "Please setenv G4NEUTRONHPDATA to point to the neutron cross-section files.");
+      dirName = getenv("G4NEUTRONHPDATA");
+      G4String tString = "/Capture";
+      dirName = dirName + tString;
+      G4cout << "+++++++++++++++++++++++++++++++++++++++++++++++++" << G4endl;
+      //    G4cout <<"Disname="<<dirName<<" numEle="<<numEle<<G4endl;
+
+      //    G4cout <<"G4NeutronHPChannel constructed"<<G4endl;
+      G4NeutronHPCaptureFS * theFS = new G4NeutronHPCaptureFS;
+      //    OtherHPCaptureFS * theFS = new OtherHPCaptureFS; 
+      GdNeutronHPCaptureFS * theGdFS = new GdNeutronHPCaptureFS;
+      
+      for ( G4int i = numEle ; i < (G4int)G4Element::GetNumberOfElements() ; i++ ) {
+  //      G4cout << "initializing theCapture "<<i<<" "<< numEle<<G4endl;
+      //    if((*(G4Element::GetElementTable()))[i]->GetName()!="Gadolinium")
+         G4cout << (*(G4Element::GetElementTable()))[i]->GetName() << G4endl;
+         (*theCapture).push_back( new G4NeutronHPChannel );
+         (*(*theCapture)[i]).Init((*(G4Element::GetElementTable()))[i], dirName);
+         if ((*(G4Element::GetElementTable()))[i]->GetZ() != 64) { 
+           (*(*theCapture)[i]).Register(theFS);
+           //	 theCapture[i].Register(theGdFS);
+         } else {
+           (*(*theCapture)[i]).Register(theGdFS);
+         }
+      }
+    delete theFS;
+    delete theGdFS;
+  }
+  numEle = G4Element::GetNumberOfElements();
+
+}

--- a/src/GdNeutronHPCapture.cc
+++ b/src/GdNeutronHPCapture.cc
@@ -100,7 +100,7 @@
       {
         index = theMaterial->GetElement(i)->GetIndex();
         rWeight = NumAtomsPerVolume[i];
-          G4cout << theMaterial->GetElement(i)->GetName() << G4endl;
+        //G4cout << theMaterial->GetElement(i)->GetName() << G4endl;
         xSec[i] = (*(*theCapture)[index]).GetXsec(aThermalE.GetThermalEnergy(aTrack,
   		                                                     theMaterial->GetElement(i),
   								     theMaterial->GetTemperature()));

--- a/src/GdNeutronHPCaptureFS.cc
+++ b/src/GdNeutronHPCaptureFS.cc
@@ -1,0 +1,213 @@
+
+
+///////////////////////////////////////////////////////////////////////////////
+//                   Spectrum of radiative neutron capture by Gadolinium           
+//                                    version 1.0.0                                
+//                                    (Sep.09.2005)                               
+                            
+//                Author : karim.zbiri@subatech.in2p3.fr                  
+
+//Modified class from original G4NeutronHPCaptureFS class to deexcite and
+//add correctly the secondary to the hadronic final state
+
+// Karim Zbiri, Aug, 2005
+///////////////////////////////////////////////////////////////////////////////
+
+
+
+#include <G4IonTable.hh>
+#include "GdNeutronHPCaptureFS.hh"
+#include "G4Gamma.hh"
+#include "G4ReactionProduct.hh"
+#include "G4Nucleus.hh"
+#include "G4PhotonEvaporation.hh"
+#include "G4Fragment.hh"
+#include "G4ParticleTable.hh" 
+#include "G4NeutronHPDataUsed.hh"
+#include "G4SystemOfUnits.hh"
+
+
+
+  G4HadFinalState * GdNeutronHPCaptureFS::ApplyYourself(const G4HadProjectile & theTrack)
+  {
+    if ( theResult.Get() == NULL ) theResult.Put( new G4HadFinalState );
+    theResult.Get()->Clear();
+
+    G4int i;
+    // prepare neutron
+    G4double eKinetic = theTrack.GetKineticEnergy();
+    const G4HadProjectile *incidentParticle = &theTrack;
+    theNeutron = const_cast<G4ParticleDefinition *>(incidentParticle->GetDefinition()) ;
+    theNeutron.SetMomentum( incidentParticle->Get4Momentum().vect() );
+    theNeutron.SetKineticEnergy( eKinetic );
+
+// prepare target
+    G4double eps = 0.0001;
+    if(targetMass<500*MeV)
+      targetMass = ( G4NucleiProperties::GetNuclearMass( static_cast<G4int>(theBaseA+eps) , static_cast<G4int>(theBaseZ+eps) )) /
+                     G4Neutron::Neutron()->GetPDGMass();
+    G4ThreeVector neutronVelocity = 1./G4Neutron::Neutron()->GetPDGMass()*theNeutron.GetMomentum();
+    G4double temperature = theTrack.GetMaterial()->GetTemperature();
+    theTarget = aNucleus.GetBiasedThermalNucleus(targetMass, neutronVelocity, temperature);
+
+// go to nucleus rest system
+    theNeutron.Lorentz(theNeutron, -1*theTarget);
+    eKinetic = theNeutron.GetKineticEnergy();
+
+// dice the photons
+
+    G4ReactionProductVector * thePhotons = NULL;    
+    thePhotons = theFinalgammas.GetGammas(theBaseA);    
+
+    // update the nucleus
+    
+    G4ThreeVector aCMSMomentum = theNeutron.GetMomentum()+theTarget.GetMomentum();
+    G4LorentzVector p4(aCMSMomentum, theTarget.GetTotalEnergy() + theNeutron.GetTotalEnergy());
+    nucleus = new G4Fragment(static_cast<G4int>(theBaseA+1), static_cast<G4int>(theBaseZ) ,p4);
+
+    //  G4Fragment * theOne = NULL;
+  
+    G4int nPhotons = 0;
+    if(thePhotons!=NULL) nPhotons=thePhotons->size();
+  
+  
+    for(i=0;i<nPhotons;i++)
+      {
+	G4Fragment * theOne;
+	G4ThreeVector pGamma(thePhotons->operator[](i)->GetMomentum());
+	G4LorentzVector gamma(pGamma,thePhotons->operator[](i)->GetTotalEnergy());
+	theOne= new G4Fragment(gamma,G4Gamma::GammaDefinition());
+	UpdateNucleus(theOne,thePhotons->operator[](i)->GetTotalEnergy());
+      }
+
+    theTwo = new G4DynamicParticle;
+    theTwo->SetDefinition(G4IonTable::GetIonTable()
+			  ->GetIon(static_cast<G4int>(theBaseZ), static_cast<G4int>(theBaseA+1), 0));
+    theTwo->SetMomentum(nucleus->GetMomentum());
+
+    //delete theOne;
+    
+// add them to the final state
+
+    G4int nParticles = nPhotons;
+    if(1==nPhotons) nParticles = 2;
+
+    // back to lab system
+    for(i=0; i<nPhotons; i++)
+    {
+      thePhotons->operator[](i)->Lorentz(*(thePhotons->operator[](i)), theTarget);
+    }
+    
+    // Recoil, if only one gamma
+    if (1==nPhotons)
+    {
+       G4DynamicParticle * theOne = new G4DynamicParticle;
+       G4ParticleDefinition * aRecoil = G4IonTable::GetIonTable()
+                                        ->GetIon(static_cast<G4int>(theBaseZ), static_cast<G4int>(theBaseA+1), 0);
+       theOne->SetDefinition(aRecoil);
+       // Now energy; 
+       // Can be done slightly better @
+       G4ThreeVector aMomentum =  theTrack.Get4Momentum().vect()
+                                 +theTarget.GetMomentum()
+				 -thePhotons->operator[](0)->GetMomentum();
+
+       G4ThreeVector theMomUnit = aMomentum.unit();
+       G4double aKinEnergy =  theTrack.GetKineticEnergy()
+                             +theTarget.GetKineticEnergy(); // gammas come from Q-value
+       G4double theResMass = aRecoil->GetPDGMass();
+       G4double theResE = aRecoil->GetPDGMass()+aKinEnergy;
+       G4double theAbsMom = std::sqrt(theResE*theResE - theResMass*theResMass);
+       G4ThreeVector theMomentum = theAbsMom*theMomUnit;
+       theOne->SetMomentum(theMomentum);
+       theResult.Get()->AddSecondary(theOne);
+    }
+
+    // Now fill in the gammas.
+    for(i=0; i<nPhotons; i++)
+    {
+      // back to lab system
+      G4DynamicParticle * theOne = new G4DynamicParticle;
+      theOne->SetDefinition(thePhotons->operator[](i)->GetDefinition());
+      theOne->SetMomentum(thePhotons->operator[](i)->GetMomentum());
+      theResult.Get()->AddSecondary(theOne);
+      delete thePhotons->operator[](i);
+    }
+    delete thePhotons; 
+    
+    //ADD deexcited nucleus
+    
+    theResult.Get()->AddSecondary(theTwo);
+
+    // clean up the primary neutron
+    theResult.Get()->SetStatusChange(stopAndKill);
+    return theResult.Get();
+  }
+
+
+
+void GdNeutronHPCaptureFS::UpdateNucleus( const G4Fragment* gamma , G4double eGamma )
+{
+  
+  G4LorentzVector p4Gamma = gamma->GetMomentum();
+  G4ThreeVector pGamma(p4Gamma.vect());
+  
+  G4LorentzVector p4Nucleus(nucleus->GetMomentum() );
+  
+  G4double m1 = G4IonTable::GetIonTable()->GetIonMass(static_cast<G4int>(nucleus->GetZ()),
+									       static_cast<G4int>(nucleus->GetA()));
+  G4double m2 = nucleus->GetZ() *  G4Proton::Proton()->GetPDGMass() + 
+    (nucleus->GetA()- nucleus->GetZ())*G4Neutron::Neutron()->GetPDGMass();
+  
+  G4double Mass = std::min(m1,m2);
+  
+  G4double newExcitation = p4Nucleus.mag() - Mass - eGamma;
+  
+  // G4cout<<" Egamma = "<<eGamma<<G4endl;
+//   G4cout<<" NEW EXCITATION ENERGY = "<< newExcitation <<G4endl;
+  
+  if(newExcitation < 0)
+    newExcitation = 0;
+  
+  G4ThreeVector p3Residual(p4Nucleus.vect() - pGamma);
+  G4double newEnergy = std::sqrt(p3Residual * p3Residual +
+				 (Mass + newExcitation) * (Mass + newExcitation));
+  G4LorentzVector p4Residual(p3Residual, newEnergy);
+  
+  // Update excited nucleus parameters
+  
+  nucleus->SetMomentum(p4Residual);
+
+  //  G4cout<<"nucleus excitation energy = "<<nucleus->GetExcitationEnergy() <<G4endl;  
+
+  return;
+}
+
+ void GdNeutronHPCaptureFS::Init(G4double A, G4double Z, G4int M, G4String & dirName, G4String & )
+  {
+    G4String tString = "/FS";
+    G4bool dbool;
+    G4NeutronHPDataUsed aFile = theNames.GetName(static_cast<G4int>(A), static_cast<G4int>(Z), M, dirName, tString, dbool);
+
+    G4String filename = aFile.GetName();
+    theBaseA = A;
+    theBaseZ = G4int(Z+.5);
+    if(!dbool || ( Z<2.5 && ( std::abs(theBaseZ - Z)>0.0001 || std::abs(theBaseA - A)>0.0001)))
+    {
+      hasAnyData = false;
+      hasFSData = false; 
+      hasXsec = false;
+      return;
+    }
+    std::ifstream theData(filename, std::ios::in);
+    
+    hasFSData = theFinalStatePhotons.InitMean(theData); 
+    if(hasFSData)
+    {
+      targetMass = theFinalStatePhotons.GetTargetMass();
+      theFinalStatePhotons.InitAngular(theData); 
+      theFinalStatePhotons.InitEnergies(theData); 
+    }
+    theData.close();
+  }
+
+

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -96,7 +96,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
   if (WCAddGd)
   {
 	  water = "Doped Water";
-	  if(!GetIsGadoliniumConcentrationSet()) SetGadoliniumConcentration(0.1*perCent);
+	  if(!G4Material::GetMaterial("Doped Water", false)) AddDopedWater();
   }
 
   // Optionally switch on the checkOverlaps. Once the geometry is debugged, switch off for 

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -94,7 +94,10 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
   //Decide if adding Gd
   water = "Water";
   if (WCAddGd)
-  {water = "Doped Water";}
+  {
+	  water = "Doped Water";
+	  if(!GetIsGadoliniumConcentrationSet()) SetGadoliniumConcentration(0.1*perCent);
+  }
 
   // Optionally switch on the checkOverlaps. Once the geometry is debugged, switch off for 
   // faster running. Checking ALL overlaps is crucial. No overlaps are allowed, otherwise

--- a/src/WCSimConstructMaterials.cc
+++ b/src/WCSimConstructMaterials.cc
@@ -53,15 +53,10 @@ void WCSimDetectorConstruction::ConstructMaterials()
 
  //---Gd doped Water
 
- a = 157.25*g/mole;
- G4Element* Gd
-    = new G4Element("Gadolinium","Gd", 64,a);
-
  density = 1.00*g/cm3;
- G4Material* DopedWater
-    = new G4Material("Doped Water",density,2);
- DopedWater->AddMaterial(Water,99.9*perCent);
- DopedWater->AddElement(Gd,0.1*perCent);
+ G4Material* DopedWater = new G4Material("Doped Water",density,2);
+ isGdConcentrationSet = false;
+ // Water and gadolinium should now be be added using SetGadoliniumConcentration
 
  //---Ice 
  
@@ -1256,4 +1251,18 @@ void WCSimDetectorConstruction::ConstructMaterials()
    //ToDo:
    G4MaterialPropertiesTable *AgPropTable = new G4MaterialPropertiesTable();
    G4MaterialPropertiesTable *AlAg1PropTable = new G4MaterialPropertiesTable();
+}
+
+void WCSimDetectorConstruction::SetGadoliniumConcentration(G4double percent){
+  if(isGdConcentrationSet){
+    G4cout << "Gadolinium concentration already set" << G4endl;
+    return;
+  }
+  G4Material * Water = G4Material::GetMaterial("Water");
+  G4Material * DopedWater = G4Material::GetMaterial("Doped Water");
+  G4double a = 157.25*g/mole;
+  G4Element* Gd = new G4Element("Gadolinium","Gd", 64,a);
+  DopedWater->AddMaterial(Water,(100.-percent)*perCent);
+  DopedWater->AddElement(Gd,percent*perCent);
+  isGdConcentrationSet = true;
 }

--- a/src/WCSimConstructMaterials.cc
+++ b/src/WCSimConstructMaterials.cc
@@ -52,11 +52,8 @@ void WCSimDetectorConstruction::ConstructMaterials()
   Water->AddElement(elO, 1);
 
  //---Gd doped Water
-
- density = 1.00*g/cm3;
- G4Material* DopedWater = new G4Material("Doped Water",density,2);
  isGdConcentrationSet = false;
- // Water and gadolinium should now be be added using SetGadoliniumConcentration
+ // Gadolinium doped water should be added later using SetGadoliniumConcentration
 
  //---Ice 
  
@@ -1133,8 +1130,6 @@ void WCSimDetectorConstruction::ConstructMaterials()
 
 
    Water->SetMaterialPropertiesTable(myMPT1);
-   //Gd doped water has the same optical properties as pure water
-   DopedWater->SetMaterialPropertiesTable(myMPT1);
    // myMPT1->DumpTable();
    
    G4MaterialPropertiesTable *myMPT2 = new G4MaterialPropertiesTable();
@@ -1254,12 +1249,15 @@ void WCSimDetectorConstruction::ConstructMaterials()
 }
 
 void WCSimDetectorConstruction::SetGadoliniumConcentration(G4double percent){
-  if(isGdConcentrationSet){
-    G4cout << "Gadolinium concentration already set" << G4endl;
-    return;
-  }
   G4Material * Water = G4Material::GetMaterial("Water");
   G4Material * DopedWater = G4Material::GetMaterial("Doped Water");
+  //Delete old doped water if it exists
+  if(DopedWater) delete DopedWater;
+  //Create new doped water material
+  DopedWater = new G4Material("Doped Water",1.00*g/cm3,2);
+  //Gd doped water has the same optical properties as pure water
+  DopedWater->SetMaterialPropertiesTable(Water->GetMaterialPropertiesTable());
+  //Set concentration
   G4double a = 157.25*g/mole;
   G4Element* Gd = new G4Element("Gadolinium","Gd", 64,a);
   DopedWater->AddMaterial(Water,(100.-percent)*perCent);

--- a/src/WCSimConstructMaterials.cc
+++ b/src/WCSimConstructMaterials.cc
@@ -1250,7 +1250,7 @@ void WCSimDetectorConstruction::ConstructMaterials()
 
 void WCSimDetectorConstruction::SetGadoliniumConcentration(G4double percent){
   G4Material * Water = G4Material::GetMaterial("Water");
-  G4Material * DopedWater = G4Material::GetMaterial("Doped Water");
+  G4Material * DopedWater = G4Material::GetMaterial("Doped Water",false);
   //Delete old doped water if it exists
   if(DopedWater) delete DopedWater;
   //Create new doped water material

--- a/src/WCSimConstructMaterials.cc
+++ b/src/WCSimConstructMaterials.cc
@@ -51,10 +51,6 @@ void WCSimDetectorConstruction::ConstructMaterials()
   Water->AddElement(elH, 2);
   Water->AddElement(elO, 1);
 
- //---Gd doped Water
- isGdConcentrationSet = false;
- // Gadolinium doped water should be added later using SetGadoliniumConcentration
-
  //---Ice 
  
  density = 0.92*g/cm3;//Ice
@@ -1248,9 +1244,9 @@ void WCSimDetectorConstruction::ConstructMaterials()
    G4MaterialPropertiesTable *AlAg1PropTable = new G4MaterialPropertiesTable();
 }
 
-void WCSimDetectorConstruction::SetGadoliniumConcentration(G4double percent){
+void WCSimDetectorConstruction::AddDopedWater(G4double percentGd){
   G4Material * Water = G4Material::GetMaterial("Water");
-  G4Material * DopedWater = G4Material::GetMaterial("Doped Water",false);
+  G4Material * DopedWater = G4Material::GetMaterial("Doped Water", false);
   //Delete old doped water if it exists
   if(DopedWater) delete DopedWater;
   //Create new doped water material
@@ -1260,7 +1256,6 @@ void WCSimDetectorConstruction::SetGadoliniumConcentration(G4double percent){
   //Set concentration
   G4double a = 157.25*g/mole;
   G4Element* Gd = new G4Element("Gadolinium","Gd", 64,a);
-  DopedWater->AddMaterial(Water,(100.-percent)*perCent);
-  DopedWater->AddElement(Gd,percent*perCent);
-  isGdConcentrationSet = true;
+  DopedWater->AddMaterial(Water,(100.-percentGd)*perCent);
+  DopedWater->AddElement(Gd,percentGd*perCent);
 }

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -96,6 +96,12 @@ WCSimDetectorConstruction::WCSimDetectorConstruction(G4int DetConfig,WCSimTuning
   //-----------------------------------------------------
 
   SavePi0Info(false);
+
+  //-----------------------------------------------------
+  // Set whether or not neutron capture info is saved
+  //-----------------------------------------------------
+
+  SaveCaptureInfo(false);
   
   //-----------------------------------------------------
   // Set the default method for implementing the PMT QE

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -516,7 +516,7 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 
 	if(command == DopingConcentration) {
 		G4cout << "Setting Gadolinium doping concentration: " << newValue << "percent" << G4endl;
-		WCSimDetector->SetGadoliniumConcentration(DopingConcentration->GetNewDoubleValue(newValue));
+            WCSimDetector->AddDopedWater(DopingConcentration->GetNewDoubleValue(newValue));
 	}
 
 	if(command == PMTSize) {

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -68,6 +68,10 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
 			  );
   WCVisChoice->AvailableForStates(G4State_PreInit, G4State_Idle);
 
+  DopedWater = new G4UIcmdWithABool("/WCSim/DopedWater", this);
+  DopedWater->SetGuidance("Set whether water is doped with Gadolinium");
+  DopedWater->SetParameterName("DopedWater", false);
+  DopedWater->AvailableForStates(G4State_PreInit, G4State_Idle);
 
   PMTSize = new G4UIcmdWithAString("/WCSim/WCPMTsize",this);
   PMTSize->SetGuidance("Set alternate PMT size for the WC (Must be entered after geometry details are set).");
@@ -421,7 +425,7 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 		} else
 		  G4cout << "That geometry choice is not defined!" << G4endl;
 	}
-  
+
 	if (command == SavePi0){
 		G4cout << "Set the flag for saving pi0 info " << newValue << G4endl;
 		if (newValue=="true"){
@@ -498,7 +502,12 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 	    G4cout << "Not egg-shaped HyperK Geometry. Detector length unchanged." << G4endl;
 	  }
 	}
-	
+
+	if(command == DopedWater) {
+		G4cout << "Setting Gadolinium doping of water: " << newValue << G4endl;
+		WCSimDetector->SetDopedWater(DopedWater->GetNewBoolValue(newValue));
+	}
+
 	if(command == PMTSize) {
 		G4cout << "SET PMT SIZE" << G4endl;
 		if ( newValue == "20inch"){

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -83,6 +83,12 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
   SavePi0->SetParameterName("SavePi0",false);
   SavePi0->SetCandidates("true false");
   SavePi0->AvailableForStates(G4State_PreInit, G4State_Idle);
+
+  SaveCapture = new G4UIcmdWithAString("/WCSim/SaveCapture", this);
+  SaveCapture->SetGuidance("true or false");
+  SaveCapture->SetParameterName("SaveCapture",false);
+  SaveCapture->SetCandidates("true false");
+  SaveCapture->AvailableForStates(G4State_PreInit, G4State_Idle);
   
   
   PMTQEMethod = new G4UIcmdWithAString("/WCSim/PMTQEMethod", this);
@@ -346,6 +352,7 @@ WCSimDetectorMessenger::~WCSimDetectorMessenger()
 {
   delete PMTConfig;
   delete SavePi0;
+  delete SaveCapture;
   delete PMTQEMethod;
   delete PMTCollEff;
   delete waterTank_Length;
@@ -416,14 +423,25 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 	}
   
 	if (command == SavePi0){
-	  G4cout << "Set the flag for saving pi0 info " << newValue << G4endl;
-	  if (newValue=="true"){
-	    WCSimDetector->SavePi0Info(true);
-	  }else if (newValue == "false"){
-	    WCSimDetector->SavePi0Info(false);
-	  }else{
-	    
-	  }
+		G4cout << "Set the flag for saving pi0 info " << newValue << G4endl;
+		if (newValue=="true"){
+			WCSimDetector->SavePi0Info(true);
+		}else if (newValue == "false"){
+			WCSimDetector->SavePi0Info(false);
+		}else{
+
+		}
+	}
+
+	if (command == SaveCapture){
+		G4cout << "Set the flag for saving neutron capture info " << newValue << G4endl;
+		if (newValue=="true"){
+			WCSimDetector->SaveCaptureInfo(true);
+		}else if (newValue == "false"){
+			WCSimDetector->SaveCaptureInfo(false);
+		}else{
+
+		}
 	}
 
 	if (command == PMTQEMethod){

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -73,6 +73,11 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
   DopedWater->SetParameterName("DopedWater", false);
   DopedWater->AvailableForStates(G4State_PreInit, G4State_Idle);
 
+  DopingConcentration = new G4UIcmdWithADouble("/WCSim/DopingConcentration", this);
+  DopingConcentration->SetGuidance("Set percentage concentration Gadolinium doping");
+  DopingConcentration->SetParameterName("DopingConcentration", false);
+  DopingConcentration->AvailableForStates(G4State_PreInit, G4State_Idle);
+
   PMTSize = new G4UIcmdWithAString("/WCSim/WCPMTsize",this);
   PMTSize->SetGuidance("Set alternate PMT size for the WC (Must be entered after geometry details are set).");
   PMTSize->SetGuidance("Available options 20inch 10inch");
@@ -506,6 +511,12 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 	if(command == DopedWater) {
 		G4cout << "Setting Gadolinium doping of water: " << newValue << G4endl;
 		WCSimDetector->SetDopedWater(DopedWater->GetNewBoolValue(newValue));
+	}
+
+
+	if(command == DopingConcentration) {
+		G4cout << "Setting Gadolinium doping concentration: " << newValue << "percent" << G4endl;
+		WCSimDetector->SetGadoliniumConcentration(DopingConcentration->GetNewDoubleValue(newValue));
 	}
 
 	if(command == PMTSize) {

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -846,8 +846,8 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
                  << " Parent: " << trj->GetParentID()
                  << " T:" << ttime
                  << " vtx:(" << start[0] << "," << start[1] << "," << start[2]
-                 << " dir:(" << dir[0] << "," << dir[1] << "," << dir[2]
-                 << " E:" << energy << G4endl;
+                 << ") dir:(" << dir[0] << "," << dir[1] << "," << dir[2]
+                 << ") E:" << energy << G4endl;
           wcsimrootevent->SetCaptureParticle(trj->GetParentID(), ipnu, ttime, start, dir, energy, id);
       }
     }

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -689,14 +689,14 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
   std::set<int> pionList;
   std::set<int> antipionList;
 
-  // Pi0 specific variables
-  Float_t pi0Vtx[3];
-  Int_t   gammaID[2];
-  Float_t gammaE[2];
-  Float_t gammaVtx[2][3];
-  Int_t   r = 0;
+    // Pi0 specific variables
+    Float_t pi0Vtx[3];
+    Int_t   gammaID[2];
+    Float_t gammaE[2];
+    Float_t gammaVtx[2][3];
+    Int_t   r = 0;
 
-  G4int n_trajectories = 0;
+    G4int n_trajectories = 0;
   if (TC)
     n_trajectories = TC->entries();
 
@@ -783,38 +783,38 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 	//G4cout<<"part 2 stop["<<l<<"]: "<< stop[l] <<G4endl;
       }
 
-
       // Add the track to the TClonesArray, watching out for times
-      if ( ! ( (ipnu==22)&&(parentType==999))  ) {
-	int choose_event=0;
+      if ( trj->GetCreatorProcessName()=="nCapture" ?
+           detectorConstructor->SaveCaptureInfo() :
+           ! ( (ipnu==22)&&(parentType==999)) ) {
+          int choose_event = 0;
 
-	if (ngates)
-	{
+          if (ngates) {
 
-	  if ( ttime > WCTM->GetTriggerTime(0)+950. && WCTM->GetTriggerTime(1)+950. > ttime ) choose_event=1; 
-	  if ( ttime > WCTM->GetTriggerTime(1)+950. && WCTM->GetTriggerTime(2)+950. > ttime ) choose_event=2; 
-	  if (choose_event >= ngates) choose_event = ngates-1; // do not overflow the number of events
-	
-	}
+              if (ttime > WCTM->GetTriggerTime(0) + 950. && WCTM->GetTriggerTime(1) + 950. > ttime) choose_event = 1;
+              if (ttime > WCTM->GetTriggerTime(1) + 950. && WCTM->GetTriggerTime(2) + 950. > ttime) choose_event = 2;
+              if (choose_event >= ngates) choose_event = ngates - 1; // do not overflow the number of events
 
-	wcsimrootevent= wcsimrootsuperevent->GetTrigger(choose_event);
-	wcsimrootevent->AddTrack(ipnu, 
-				  flag, 
-				  mass, 
-				  mommag, 
-				  energy,
-				  startvol, 
-				  stopvol, 
-				  dir, 
-				  pdir, 
-				  stop,
-				  start,
-				  parentType,
-				 ttime,id); 
+          }
+
+          wcsimrootevent = wcsimrootsuperevent->GetTrigger(choose_event);
+          wcsimrootevent->AddTrack(ipnu,
+                                   flag,
+                                   mass,
+                                   mommag,
+                                   energy,
+                                   startvol,
+                                   stopvol,
+                                   dir,
+                                   pdir,
+                                   stop,
+                                   start,
+                                   parentType,
+                                   ttime, id);
       }
       
 
-      if (detectorConstructor->SavePi0Info() == true)
+      if (detectorConstructor->SavePi0Info())
       {
 	G4cout<<"Pi0 parentType: " << parentType <<G4endl;
 	if (parentType == 111)
@@ -839,6 +839,16 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 		wcsimrootevent->SetPi0Info(pi0Vtx, gammaID, gammaE, gammaVtx);
 	  }
 	}
+      }
+
+      if (detectorConstructor->SaveCaptureInfo() && trj->GetCreatorProcessName()=="nCapture"){
+          G4cout << "Capture particle: " << trj->GetParticleName()
+                 << " Parent: " << trj->GetParentID()
+                 << " T:" << ttime
+                 << " vtx:(" << start[0] << "," << start[1] << "," << start[2]
+                 << " dir:(" << dir[0] << "," << dir[1] << "," << dir[2]
+                 << " E:" << energy << G4endl;
+          wcsimrootevent->SetCaptureParticle(trj->GetParentID(), ipnu, ttime, start, dir, energy, id);
       }
     }
   }

--- a/src/WCSimPhysicsListFactory.cc
+++ b/src/WCSimPhysicsListFactory.cc
@@ -1,4 +1,14 @@
+#include <G4ProcessTable.hh>
+#include <G4Neutron.hh>
+#include <G4NeutronHPCapture.hh>
+#include <G4NeutronHPCaptureData.hh>
+#include <G4HadronCaptureProcess.hh>
+#include <G4NeutronRadCapture.hh>
+#include <G4NeutronCaptureXS.hh>
+#include <G4CrossSectionDataSetRegistry.hh>
 #include "WCSimPhysicsListFactory.hh"
+
+#include "GdNeutronHPCapture.hh"
 
 #include "G4PhysicalConstants.hh"
 #include "G4SystemOfUnits.hh"
@@ -42,9 +52,51 @@ void WCSimPhysicsListFactory::ConstructParticle()
   G4VModularPhysicsList::ConstructParticle();
 }
 
-void WCSimPhysicsListFactory::ConstructProcess()
-{
-  G4VModularPhysicsList::ConstructProcess();
+void WCSimPhysicsListFactory::ConstructProcess() {
+    G4VModularPhysicsList::ConstructProcess();
+    if (nCaptModelChoice.compareTo("Default", G4String::ignoreCase) == 0) return;
+    G4ProcessTable *table = G4ProcessTable::GetProcessTable();
+    G4ProcessManager *manager = G4Neutron::Neutron()->GetProcessManager();
+    if (manager) {
+        G4VProcess *captureProcess = table->FindProcess("nCapture", G4Neutron::Neutron());
+
+        if (captureProcess) {
+            G4cout << "Removing default nCapture process" << G4endl;
+            manager->RemoveProcess(captureProcess);
+        }
+
+        G4HadronCaptureProcess *theCaptureProcess = new G4HadronCaptureProcess;
+        manager->AddDiscreteProcess(theCaptureProcess);
+
+        G4NeutronCaptureXS *xsNeutronCaptureXS = (G4NeutronCaptureXS *) G4CrossSectionDataSetRegistry::Instance()->GetCrossSectionDataSet(G4NeutronCaptureXS::Default_Name());
+        theCaptureProcess->AddDataSet(xsNeutronCaptureXS);
+
+        G4HadronicInteraction *theNeutronRadCapture = new G4NeutronRadCapture();
+
+        if (nCaptModelChoice.compareTo("Rad", G4String::ignoreCase) != 0) {
+            theCaptureProcess->AddDataSet(new G4NeutronHPCaptureData);
+            //G4NeutronHPCapture *theNeutronHPCapture = new G4NeutronHPCapture();
+            G4HadronicInteraction *theNeutronHPCapture;
+            if (nCaptModelChoice.compareTo("GLG4Sim", G4String::ignoreCase) == 0) {
+                G4cout << "Enabling GLG4Sim HP nCapture process" << G4endl;
+                theNeutronHPCapture = new GdNeutronHPCapture();
+            } else if (nCaptModelChoice.compareTo("GLG4Sim", G4String::ignoreCase) == 0) {
+                G4cout << "Enabling HP nCapture process" << G4endl;
+                theNeutronHPCapture = new G4NeutronHPCapture();
+            }
+            else{
+                G4cout << "Unknown model choice. Using HP." << G4endl;
+                theNeutronHPCapture = new G4NeutronHPCapture();
+            }
+            theNeutronHPCapture->SetMinEnergy(0);
+            theNeutronHPCapture->SetMaxEnergy(20 * MeV);
+            theCaptureProcess->RegisterMe(theNeutronHPCapture);
+            theCaptureProcess->AddDataSet(new G4NeutronHPCaptureData);
+            theNeutronRadCapture->SetMinEnergy(19.9 * MeV);
+        }
+        G4cout << "Enabling RadCapture nCapture process" << G4endl;
+        theCaptureProcess->RegisterMe(theNeutronRadCapture);
+    }
 }
 
 void WCSimPhysicsListFactory::SetCuts()
@@ -66,8 +118,13 @@ void WCSimPhysicsListFactory::SetCuts()
 }
 
 void WCSimPhysicsListFactory::SetList(G4String newvalue){
-  G4cout << "Setting Physics list to " << newvalue << " and delaying initialization" << G4endl;
-  PhysicsListName = newvalue;
+    G4cout << "Setting Physics list to " << newvalue << " and delaying initialization" << G4endl;
+    PhysicsListName = newvalue;
+}
+
+void WCSimPhysicsListFactory::SetnCaptModel(G4String newvalue){
+    G4cout << "Setting neutron capture model to " << newvalue << G4endl;
+    nCaptModelChoice = newvalue;
 }
 
 void WCSimPhysicsListFactory::InitializeList(){

--- a/src/WCSimPhysicsListFactory.cc
+++ b/src/WCSimPhysicsListFactory.cc
@@ -6,6 +6,7 @@
 #include <G4NeutronRadCapture.hh>
 #include <G4NeutronCaptureXS.hh>
 #include <G4CrossSectionDataSetRegistry.hh>
+#include <G4HadronicInteractionRegistry.hh>
 #include "WCSimPhysicsListFactory.hh"
 
 #include "GdNeutronHPCapture.hh"
@@ -63,6 +64,9 @@ void WCSimPhysicsListFactory::ConstructProcess() {
         if (captureProcess) {
             G4cout << "Removing default nCapture process" << G4endl;
             manager->RemoveProcess(captureProcess);
+            // Due to bug in Geant (fixed in v4.10.2) must remove old NeutronHPCapture from registry, if it exists, to prevent segfault on cleanup
+            G4HadronicInteractionRegistry *registry = G4HadronicInteractionRegistry::Instance();
+            registry->RemoveMe(registry->FindModel("NeutronHPCapture"));
         }
 
         G4HadronCaptureProcess *theCaptureProcess = new G4HadronCaptureProcess;

--- a/src/WCSimPhysicsListFactory.cc
+++ b/src/WCSimPhysicsListFactory.cc
@@ -84,7 +84,7 @@ void WCSimPhysicsListFactory::ConstructProcess() {
             if (nCaptModelChoice.compareTo("GLG4Sim", G4String::ignoreCase) == 0) {
                 G4cout << "Enabling GLG4Sim HP nCapture process" << G4endl;
                 theNeutronHPCapture = new GdNeutronHPCapture();
-            } else if (nCaptModelChoice.compareTo("GLG4Sim", G4String::ignoreCase) == 0) {
+            } else if (nCaptModelChoice.compareTo("HP", G4String::ignoreCase) == 0) {
                 G4cout << "Enabling HP nCapture process" << G4endl;
                 theNeutronHPCapture = new G4NeutronHPCapture();
             }

--- a/src/WCSimPhysicsListFactoryMessenger.cc
+++ b/src/WCSimPhysicsListFactoryMessenger.cc
@@ -23,11 +23,19 @@ WCSimPhysicsListFactoryMessenger::WCSimPhysicsListFactoryMessenger(WCSimPhysicsL
   physListCmd->SetCandidates(ValidListsString);  // ToDo get list of physics lists from G4PhysicsListFactory
 
   SetNewValue(physListCmd, defaultList);
+
+  G4String captureModelsString = "Default HP Rad GLG4Sim";
+  G4String captureModelGuidance = "Available options: " + captureModelsString;
+  nCaptureModelCmd = new G4UIcmdWithAString("/WCSim/physics/nCapture",this);
+  nCaptureModelCmd->SetGuidance(captureModelGuidance);
+  nCaptureModelCmd->SetDefaultValue("Default");
+  nCaptureModelCmd->SetCandidates(captureModelsString);
 }
 
 WCSimPhysicsListFactoryMessenger::~WCSimPhysicsListFactoryMessenger()
 {
   delete physListCmd;
+  delete nCaptureModelCmd;
   //delete WCSimDir;
 }
 
@@ -35,5 +43,7 @@ void WCSimPhysicsListFactoryMessenger::SetNewValue(G4UIcommand* command, G4Strin
 {
   if (command == physListCmd)
     thisWCSimPhysicsListFactory->SetList(newValue);
-
+  else if (command == nCaptureModelCmd){
+    thisWCSimPhysicsListFactory->SetnCaptModel(newValue);
+  }
 }

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -237,8 +237,10 @@ void WCSimRootTrigger::SetCaptureParticle(Int_t parent,
 {
     WCSimRootCapture * capture = 0;
     for(int i = 0; i<fCaptures->GetEntriesFast(); i++){
-        if(((WCSimRootCapture*)fCaptures->At(i))->GetCaptureParent() == parent)
-            capture = (WCSimRootCapture*)fCaptures->At(i);
+        if(((WCSimRootCapture*)fCaptures->At(i))->GetCaptureParent() == parent) {
+            capture = (WCSimRootCapture *) fCaptures->At(i);
+            break;
+        }
     }
     if(capture == 0) {
         TClonesArray &captures = *fCaptures;

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -56,6 +56,8 @@ WCSimRootTrigger::WCSimRootTrigger()
   fNcherenkovdigihits = 0;
   fSumQ = 0;
 
+  fCaptures = 0;
+
   fTriggerType = kTriggerUndefined;
   fTriggerInfo.clear();
   
@@ -98,6 +100,10 @@ void WCSimRootTrigger::Initialize() //actually allocate memory for things in her
   fNcherenkovdigihits = 0;
   fSumQ = 0;
 
+  // TClonesArray of WCSimRootCaptures
+  fCaptures = new TClonesArray("WCSimRootCapture", 100);
+  fNcaptures = 0;
+
   fTriggerType = kTriggerUndefined;
   fTriggerInfo.clear();
   
@@ -125,12 +131,14 @@ WCSimRootTrigger::~WCSimRootTrigger()
     fTracks->Delete();            
     fCherenkovHits->Delete();      
     fCherenkovHitTimes->Delete();   
-    fCherenkovDigiHits->Delete();  
+    fCherenkovDigiHits->Delete();
+    fCaptures->Delete();
     
     delete   fTracks;            
     delete   fCherenkovHits;      
     delete   fCherenkovHitTimes;   
-    delete   fCherenkovDigiHits; 
+    delete   fCherenkovDigiHits;
+    delete   fCaptures;
   }
   mystopw->Stop();
 
@@ -159,6 +167,9 @@ void WCSimRootTrigger::Clear(Option_t */*option*/)
   fNcherenkovdigihits = 0;
   fSumQ = 0;
 
+  // TClonesArray of WCSimRootCaptures
+  fNcaptures = 0;
+
   // remove whatever's in the arrays
   // but don't deallocate the arrays themselves
 
@@ -166,6 +177,7 @@ void WCSimRootTrigger::Clear(Option_t */*option*/)
   fCherenkovHits->Delete();      
   fCherenkovHitTimes->Delete();   
   fCherenkovDigiHits->Delete();
+  fCaptures->Delete();
 
   fTriggerType = kTriggerUndefined;
   fTriggerInfo.clear();
@@ -202,41 +214,118 @@ void WCSimRootTrigger::SetTriggerInfo(TriggerType_t trigger_type,
 
 //_____________________________________________________________________________
 
-void WCSimRootTrigger::SetPi0Info(Float_t pi0Vtx[3], 
-				 Int_t   gammaID[2], 
-				 Float_t gammaE[2],
-				 Float_t gammaVtx[2][3])
+void WCSimRootTrigger::SetPi0Info(Float_t pi0Vtx[3],
+                                  Int_t   gammaID[2],
+                                  Float_t gammaE[2],
+                                  Float_t gammaVtx[2][3])
 {
-  fPi0.Set(pi0Vtx, 
-	   gammaID, 
-	   gammaE,
-	   gammaVtx);
+    fPi0.Set(pi0Vtx,
+             gammaID,
+             gammaE,
+             gammaVtx);
 }
 
 //_____________________________________________________________________________
 
-void WCSimRootPi0::Set(Float_t pi0Vtx[3], 
-			Int_t   gammaID[2], 
-			Float_t gammaE[2],
-			Float_t gammaVtx[2][3])
+void WCSimRootTrigger::SetCaptureParticle(Int_t parent,
+                                          Int_t ipnu,
+                                          Float_t time,
+                                          Float_t vtx[3],
+                                          Float_t dir[3],
+                                          Float_t energy,
+                                          Int_t id)
 {
-  for (int i=0;i<2;i++)
-  {
-    fGammaID[i] = gammaID[i];
-    fGammaE[i]  = gammaE[i];
-  }
-
-  for (int j=0;j<3;j++)
-  {
-    fPi0Vtx[j]      = pi0Vtx[j];
-    fGammaVtx[0][j] = gammaVtx[0][j];
-    fGammaVtx[1][j] = gammaVtx[1][j];
-  }
+    WCSimRootCapture * capture = 0;
+    for(int i = 0; i<fCaptures->GetEntriesFast(); i++){
+        if(((WCSimRootCapture*)fCaptures->At(i))->GetCaptureParent() == parent)
+            capture = (WCSimRootCapture*)fCaptures->At(i);
+    }
+    if(capture == 0) {
+        TClonesArray &captures = *fCaptures;
+        capture = new(captures[fNcaptures++]) WCSimRootCapture(parent);
+    }
+    if(ipnu==22) capture->AddGamma(id, energy, dir);
+    else capture->SetInfo(vtx, time, ipnu);
 }
 
 //_____________________________________________________________________________
 
-WCSimRootTrack *WCSimRootTrigger::AddTrack(Int_t ipnu, 
+void WCSimRootPi0::Set(Float_t pi0Vtx[3],
+                       Int_t   gammaID[2],
+                       Float_t gammaE[2],
+                       Float_t gammaVtx[2][3])
+{
+    for (int i=0;i<2;i++)
+    {
+        fGammaID[i] = gammaID[i];
+        fGammaE[i]  = gammaE[i];
+    }
+
+    for (int j=0;j<3;j++)
+    {
+        fPi0Vtx[j]      = pi0Vtx[j];
+        fGammaVtx[0][j] = gammaVtx[0][j];
+        fGammaVtx[1][j] = gammaVtx[1][j];
+    }
+}
+
+//_____________________________________________________________________________
+
+WCSimRootCapture::WCSimRootCapture(Int_t captureParent)
+{
+    fCaptureParent = captureParent;
+    fNGamma = 0;
+    fTotalGammaE = 0;
+    fGammas = new TClonesArray("WCSimRootCaptureGamma", 10);
+    IsZombie=false;
+}
+
+//_____________________________________________________________________________
+
+WCSimRootCapture::~WCSimRootCapture()
+{
+    if(!IsZombie) {
+        fGammas->Delete();
+        delete fGammas;
+    }
+}
+
+//_____________________________________________________________________________
+
+void WCSimRootCapture::SetInfo(Float_t captureVtx[3],
+                               Float_t captureT,
+                               Int_t   captureNucleus)
+{
+    for (int i=0;i<3;i++) fCaptureVtx[i] = captureVtx[i];
+    fCaptureT = captureT;
+    fCaptureNucleus = captureNucleus;
+}
+
+//_____________________________________________________________________________
+
+void WCSimRootCapture::AddGamma(Int_t   gammaID,
+                                Float_t gammaE,
+                                Float_t gammaDir[3])
+{
+    TClonesArray &gammas = *fGammas;
+    new(gammas[fNGamma]) WCSimRootCaptureGamma(gammaID, gammaE, gammaDir);
+    fTotalGammaE += gammaE;
+    fNGamma++;
+}
+
+//_____________________________________________________________________________
+
+WCSimRootCaptureGamma::WCSimRootCaptureGamma(Int_t id,
+                                             Float_t energy,
+                                             Float_t *dir) {
+    fID = id;
+    fEnergy = energy;
+    for(int i=0;i<3;i++) fDir[i] = dir[i];
+}
+
+//_____________________________________________________________________________
+
+WCSimRootTrack *WCSimRootTrigger::AddTrack(Int_t ipnu,
 					   Int_t flag, 
 					   Float_t m, 
 					   Float_t p, 
@@ -477,6 +566,3 @@ void WCSimRootEvent::Reset(Option_t* /*o*/)
 {
   //nothing for now
 }
-
-
-

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -17,7 +17,7 @@ WCSimTrackingAction::WCSimTrackingAction()
   ProcessList.insert("Decay") ;                         // Michel e- from pi+ and mu+
   //ProcessList.insert("muMinusCaptureAtRest") ;          // Includes Muon decay from K-shell: for Michel e- from mu0. This dominates/replaces the mu- decay (noticed when switching off this process in PhysicsList)                                                   // TF: IMPORTANT: ONLY USE FROM G4.9.6 onwards because buggy/double counting before.
   ////////// ToDo: switch ON the above when NuPRISM uses G4 >= 4.9.6
-
+  ProcessList.insert("nCapture");
 
 //   ProcessList.insert("conv");
   ParticleList.insert(111); // pi0


### PR DESCRIPTION
This pull request includes:

- Option to set Gd doping and concentration in mac file (default is for undoped water if these lines are missing, unless Gd is added manually in detector setup code in which case default concentration is 0.1%), set using lines like:
```
/WCSim/DopedWater false
/WCSim/DopingConcentration 0.1
```
- Option to save neutron capture truth information (capture position, time, nucleus, and resulting gamma directions and energies) as well as neutron tracks to output file:
```
/WCSim/SaveCapture true
```
- Additional neutron capture model code added for alternative GLG4Sim and ANNRI models
- Option to choose neutron capture model in jobOptions.mac file, can be "Default" (whatever the current physics list defaults to), "HP", "Rad", "GLG4Sim" or "ANNRI". E.g.:
```
/WCSim/physics/nCapture HP
```