### PR TITLE
New geometry: 6 m tall ID populated with mPMTs

### DIFF
--- a/WCSim.mac
+++ b/WCSim.mac
@@ -8,22 +8,23 @@
 # Default config if you do nothing is currently SuperK
 #
 
-/WCSim/WCgeom nuPRISM
+#/WCSim/WCgeom nuPRISM
 
 #Select which PMT to use
-/WCSim/nuPRISM/SetPMTType PMT8inch
-/WCSim/nuPRISM/SetPMTPercentCoverage 40
+#/WCSim/nuPRISM/SetPMTType PMT8inch
+#/WCSim/nuPRISM/SetPMTPercentCoverage 40
 #Set height of nuPRISM inner detector
-/WCSim/nuPRISM/SetDetectorHeight 10. m
+#/WCSim/nuPRISM/SetDetectorHeight 6. m
 #Set vertical position of inner detector, in beam coordinates
-/WCSim/nuPRISM/SetDetectorVerticalPosition -10. m
+#/WCSim/nuPRISM/SetDetectorVerticalPosition 0. m
 #Set diameter of inner detector
-/WCSim/nuPRISM/SetDetectorDiameter 6. m
-/WCSim/Construct
+#/WCSim/nuPRISM/SetDetectorDiameter 8. m
+#/WCSim/Construct
 
 #Use mPMTs settings (uncomment/delete the above)
 #/WCSim/WCgeom nuPRISM_mPMT
-#/WCSim/Construct
+/WCSim/WCgeom nuPRISMShort_mPMT
+/WCSim/Construct
 ## OR for single mPMT mode or updating mPMT parameters:
 #/control/execute macros/mPMT_nuPrism1.mac         ## mPMT options: mPMT_nuPrism1.mac and 2.mac
 

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -91,6 +91,7 @@ public:
   void SetHyperKGeometry();
   void SetNuPrismGeometry(G4String PMTType, G4double PMTCoverage, G4double detectorHeight, G4double detectorDiameter, G4double verticalPosition);
   void SetNuPrism_mPMTGeometry();
+  void SetNuPrismShort_mPMTGeometry();
   void SetDefaultNuPrismGeometry();
   void UpdateGeometry();
 

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -447,6 +447,60 @@ void WCSimDetectorConstruction::SetNuPrism_mPMTGeometry()
     WCAddGd               = false;
 }
 
+// Short version of NuPRISM with mPMTs: 6 m tall ID
+// These are defaults that can be altered through the macros
+void WCSimDetectorConstruction::SetNuPrismShort_mPMTGeometry()
+{
+    WCDetectorName = "NuPRISMShort_mPMT";
+    WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
+	mPMT_ID_PMT = "PMT3inchR12199_02";    //can be changed in macro through mPMT settings.
+	mPMT_OD_PMT = "PMT3inchR12199_02";
+    WCSimPMTObject * PMT = CreatePMTObject(mPMT_ID_PMT, WCIDCollectionName);
+    WCPMTName = PMT->GetPMTName();
+    WCPMTExposeHeight = PMT->GetExposeHeight();
+    WCPMTRadius = PMT->GetRadius();
+
+	//mPMT params go first because detector depends on it:
+	vessel_cyl_height = 38.*CLHEP::mm;    //option A, option B would be 277 mm
+	vessel_radius_curv = 342.*CLHEP::mm;  //needs to include the vessel thickness, as we construct from outside inwards.
+	vessel_radius = 254.*CLHEP::mm;
+	dist_pmt_vessel = 2*CLHEP::mm;      
+	orientation = PERPENDICULAR;
+	mPMT_outer_material = "G4_PLEXIGLASS";
+	mPMT_inner_material = "Air";               // TODO: real air, hence update abs_length
+	mPMT_material_pmtAssembly = "SilGel";
+	mPMT_outer_material_d = 10*CLHEP::mm;
+	
+	// Radius of cone at z=reflectorHeight
+	id_reflector_height = 6.53*CLHEP::mm;        // for a radius of 7.25mm, for hex: 5.4mm (radius of 6mm)
+	id_reflector_z_offset = 4.8*CLHEP::mm;       //from KM3Net CAD drawings
+	id_reflector_angle = 48.*CLHEP::deg;         // Need to be remeasured for different PMT curvature 
+	mPMT_pmt_openingAngle = 8.7*CLHEP::deg;     // for hex: 8.5deg
+	G4double vessel_tot_height = vessel_radius + vessel_cyl_height;
+	
+	// parameters related to filling the ID mPMT
+	nID_PMTs = 19;
+	config_file = wcsimdir_path+"/mPMT-configfiles/mPMTconfig_19_nuPrism_3ring.txt"; // for smaller reflector, use: mPMTconfig_19_nuPrism.txt (hex)
+
+	WCIDHeight               = 6.0*CLHEP::m;
+	WCIDDiameter             = 8.0*CLHEP::m;
+    WCIDVerticalPosition     = 0.;
+	
+	WCBarrelPMTOffset     = vessel_tot_height;
+    WCPMTperCellHorizontal = 2.0; // 2 per phi
+    WCPMTperCellVertical   = 1.0;
+
+	// Numbers below are based on R.Henderson's 832 module tank design
+    WCBarrelNumPMTHorizontal = 40;
+    WCBarrelNRings        = 9; // Scaled from 10.42 m tall detector.
+    WCCapPMTSpacing       = (pi*WCIDDiameter/WCBarrelNumPMTHorizontal);
+	// This is tuned to give a 6-5-5-4-3-1 config in one quarter of the cap
+	// And results in 832 mPMT modules as currently in Robert's Design
+    WCCapEdgeLimit        = 3.3*m; 
+    WCBlackSheetThickness = 2.0*cm;    // deprecate soon.
+    WCAddGd               = false;
+}
+
 void WCSimDetectorConstruction::SetTestSinglemPMTGeometry()
 {
   WCDetectorName = "TestSinglemPMT";

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -28,6 +28,7 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
 			  "EggShapedHyperK_withHPD\n"
                           "nuPRISM\n"
                           "nuPRISM_mPMT\n"
+    			  "nuPRISMShort_mPMT\n"
 			  "Cylinder_60x74_3inchmPMT_14perCent\n"
 			  "Cylinder_60x74_3inchmPMT_40perCent\n"
 			  "Cylinder_60x74_3inch_14perCent\n"
@@ -48,6 +49,7 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
 			   "EggShapedHyperK_withHPD "
                            "nuPRISM "
                            "nuPRISM_mPMT "
+			   "nuPRISMShort_mPMT "
 			   "Cylinder_60x74_3inchmPMT_14perCent "
 			   "Cylinder_60x74_3inchmPMT_40perCent "
 			   "Cylinder_60x74_3inch_14perCent "
@@ -411,6 +413,9 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
                 } else if ( newValue == "nuPRISM_mPMT") {
 		  WCSimDetector->SetIsNuPrism(true);
 		  WCSimDetector->SetNuPrism_mPMTGeometry();
+                } else if ( newValue == "nuPRISMShort_mPMT") {
+		  WCSimDetector->SetIsNuPrism(true);
+		  WCSimDetector->SetNuPrismShort_mPMTGeometry();
 		} else
 		  G4cout << "That geometry choice is not defined!" << G4endl;
 	}


### PR DESCRIPTION
Inner detector size is 6 x 8 m. Number of PMTs on the end-caps is the same, and the number of rings in the barrel was scaled from 16 (for 10 m tank) to 9.

![screenshot from 2017-11-20 21-40-50](https://user-images.githubusercontent.com/11177614/33052655-ea6069b0-ce3d-11e7-9599-979e87012df6.png)
![screenshot from 2017-11-20 21-43-50](https://user-images.githubusercontent.com/11177614/33052662-ee2f3b3e-ce3d-11e7-9760-7e10aa54b60a.png)
![screenshot from 2017-11-20 21-46-01](https://user-images.githubusercontent.com/11177614/33052672-f5095b6a-ce3d-11e7-8c7d-ca64b1034b1e.png)