### PR TITLE
Update the event generation

### DIFF
--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -285,7 +285,7 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
         //loading events until one is found within the detector or there are
         //no more interaction to simulate for this event.
         //The current neut vector files do not correspond directly to the detector dimensions, so only keep those events within the detector
-	while (sqrt(pow(xPos,2)+pow(zPos,2))*m > (myDetector->GetWCIDDiameter()/2. - 20*cm) || (abs(yPos*m - myDetector->GetWCIDVerticalPosition()) > (myDetector->GetWCIDHeight()/2. - 20*cm))){
+        while (sqrt(pow(xPos,2)+pow(zPos,2))*m > (myDetector->GetWCIDDiameter()/2.) || (abs(yPos*m - myDetector->GetWCIDVerticalPosition()) > (myDetector->GetWCIDHeight()/2.))){
             //Load another event
             if (fEvNum<fNEntries){
                 fRooTrackerTree->GetEntry(fEvNum);
@@ -331,7 +331,15 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
         particleGun->GeneratePrimaryVertex(anEvent);  //Place vertex in stack
 
         // Now simulate the outgoing particles
-        for (int i = 3; i < fTmpRootrackerVtx->StdHepN; i++){
+        for (int i = 0; i < fTmpRootrackerVtx->StdHepN; i++){
+
+            // Skip the initial neutrino, target nucleus and target nucleon
+            if( i < 3){
+                int pdg = abs(fTmpRootrackerVtx->StdHepPdg[i]);
+                if(pdg > 100000 || pdg == 12 || pdg == 14 || pdg == 2112 || pdg == 2212){
+                    continue;
+                }
+            }
 
             xDir=fTmpRootrackerVtx->StdHepP4[i][0];
             yDir=fTmpRootrackerVtx->StdHepP4[i][1];


### PR DESCRIPTION
Update the event generation to generate events right out to the edge of the E61 ID

Also make sure that the initial state particles are skipped correctly -
coherent events do not have an initial nucleon, so may have been missed
in the last method.