### PR TITLE
WCTE Geometry

### DIFF
--- a/WCSim.mac
+++ b/WCSim.mac
@@ -26,6 +26,7 @@
 
 #Use mPMTs settings (uncomment/delete the above)
 #/WCSim/WCgeom nuPRISM_mPMT
+#/WCSim/WCgeom nuPRISMBeamTest_mPMT
 /WCSim/WCgeom nuPRISMShort_mPMT
 # Set Gadolinium doping (concentration is in percent)
 #/WCSim/DopingConcentration 0.1

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -91,6 +91,7 @@ public:
   void SetHyperKGeometry();
   void SetNuPrismGeometry(G4String PMTType, G4double PMTCoverage, G4double detectorHeight, G4double detectorDiameter, G4double verticalPosition);
   void SetNuPrism_mPMTGeometry();
+  void SetNuPrismBeamTest_mPMTGeometry();
   void SetNuPrismShort_mPMTGeometry();
   void SetDefaultNuPrismGeometry();
   void UpdateGeometry();

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -262,6 +262,11 @@ public:
   // Set if nuPRISM
   void   SetIsNuPrism(G4bool choice) {isNuPrism = choice;}
   G4bool GetIsNuPrism() {return isNuPrism;}
+  
+  // Set if nuPRISM for WCTE (NuPRISMBeamTest)
+  // M.Shinoki added Jun.04,2020
+  void   SetIsNuPrismBeamTest(G4bool choice) {isNuPrismBeamTest = choice;}
+  G4bool GetIsNuPrismBeamTest() {return isNuPrismBeamTest;}
 
   void   SetPMTType(G4String type) {
     WCPMTType = type;
@@ -519,6 +524,7 @@ private:
 
   // Add bool to indicate whether we load nuPRISM geometry  
   G4bool isNuPrism;
+  G4bool isNuPrismBeamTest;
   G4String WCPMTType;
   // G4double WCPMTCoverage; //TF: already using this variable "WCPMTPercentCoverage
 

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -1319,10 +1319,13 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
   for ( int i = -CapNCell ; i <  CapNCell; i++) {
     for (int j = -CapNCell ; j <  CapNCell; j++)   {
 
-       
+      // When you use WCTE geometry, please change xoffset and yoffset. (M.Shinoki)
+      // For IWCD (NuPRISM_mPMT Geometry)
       xoffset = i*WCCapPMTSpacing + WCCapPMTSpacing*0.5;
       yoffset = j*WCCapPMTSpacing + WCCapPMTSpacing*0.5;
-
+      // For WCTE (NuPRISMBeamTest_mPMT Geometry)
+      //xoffset = i*WCCapPMTSpacing;
+      //yoffset = j*WCCapPMTSpacing;
       
       G4ThreeVector cellpos = G4ThreeVector(xoffset, yoffset, 0);     
       //      G4double WCBarrelEffRadius = WCIDDiameter/2. - WCCapPMTSpacing;

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -1319,14 +1319,15 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
   for ( int i = -CapNCell ; i <  CapNCell; i++) {
     for (int j = -CapNCell ; j <  CapNCell; j++)   {
 
-      // When you use WCTE geometry, please change xoffset and yoffset. (M.Shinoki)
+      // Jun. 04, 2020 by M.Shinoki
       // For IWCD (NuPRISM_mPMT Geometry)
       xoffset = i*WCCapPMTSpacing + WCCapPMTSpacing*0.5;
       yoffset = j*WCCapPMTSpacing + WCCapPMTSpacing*0.5;
       // For WCTE (NuPRISMBeamTest_mPMT Geometry)
-      //xoffset = i*WCCapPMTSpacing;
-      //yoffset = j*WCCapPMTSpacing;
-      
+      if (isNuPrismBeamTest){
+      	xoffset = i*WCCapPMTSpacing;
+      	yoffset = j*WCCapPMTSpacing;
+      }
       G4ThreeVector cellpos = G4ThreeVector(xoffset, yoffset, 0);     
       //      G4double WCBarrelEffRadius = WCIDDiameter/2. - WCCapPMTSpacing;
       //      double comp = xoffset*xoffset + yoffset*yoffset 

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -447,6 +447,57 @@ void WCSimDetectorConstruction::SetNuPrism_mPMTGeometry()
     WCAddGd               = false;
 }
 
+// WCTE with mPMTs (M.Shinoki)
+void WCSimDetectorConstruction::SetNuPrismBeamTest_mPMTGeometry()
+{
+    WCDetectorName = "NuPRISMBeamTest_mPMT";
+    WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
+	mPMT_ID_PMT = "PMT3inchR12199_02";    //can be changed in macro through mPMT settings.
+	mPMT_OD_PMT = "PMT3inchR12199_02";
+    WCSimPMTObject * PMT = CreatePMTObject(mPMT_ID_PMT, WCIDCollectionName);
+    WCPMTName = PMT->GetPMTName();
+    WCPMTExposeHeight = PMT->GetExposeHeight();
+    WCPMTRadius = PMT->GetRadius();
+
+	//mPMT params go first because detector depends on it:
+	vessel_cyl_height = 38.*CLHEP::mm;    //option A, option B would be 277 mm
+	vessel_radius_curv = 342.*CLHEP::mm;  //needs to include the vessel thickness, as we construct from outside inwards.
+	vessel_radius = 254.*CLHEP::mm;
+	dist_pmt_vessel = 2*CLHEP::mm;      
+	orientation = PERPENDICULAR;
+	mPMT_outer_material = "G4_PLEXIGLASS";
+	mPMT_inner_material = "Air";               // TODO: real air, hence update abs_length
+	mPMT_material_pmtAssembly = "SilGel";
+	mPMT_outer_material_d = 10*CLHEP::mm;
+	
+	// Radius of cone at z=reflectorHeight
+	id_reflector_height = 6.53*CLHEP::mm;        // for a radius of 7.25mm, for hex: 5.4mm (radius of 6mm)
+	id_reflector_z_offset = 4.8*CLHEP::mm;       //from KM3Net CAD drawings
+	id_reflector_angle = 48.*CLHEP::deg;         // Need to be remeasured for different PMT curvature 
+	mPMT_pmt_openingAngle = 8.7*CLHEP::deg;     // for hex: 8.5deg
+	G4double vessel_tot_height = vessel_radius + vessel_cyl_height;
+	
+	// parameters related to filling the ID mPMT
+	nID_PMTs = 19;
+	config_file = wcsimdir_path+"/mPMT-configfiles/mPMTconfig_19_nuPrism_3ring.txt"; // for smaller reflector, use: mPMTconfig_19_nuPrism.txt (hex)
+
+	WCIDHeight               = 3.38*CLHEP::m;
+    	WCIDDiameter             = 3.696*CLHEP::m;
+    	WCIDVerticalPosition     = 0.;
+	
+	WCBarrelPMTOffset     = 300.*CLHEP::mm;
+    WCPMTperCellHorizontal = 1.0; // 1 per phi
+    WCPMTperCellVertical   = 1.0;
+
+    WCBarrelNumPMTHorizontal = 18;
+    WCBarrelNRings        = 5;
+    //WCCapPMTSpacing       = (pi*WCIDDiameter/WCBarrelNumPMTHorizontal);
+    WCCapPMTSpacing       = 0.58*CLHEP::m;
+    WCCapEdgeLimit        = 1.551*m; 
+    WCBlackSheetThickness = 2.0*cm;    // deprecate soon.
+    WCAddGd               = false;
+}
+
 // Short version of NuPRISM with mPMTs: 6 m tall ID
 // These are defaults that can be altered through the macros
 void WCSimDetectorConstruction::SetNuPrismShort_mPMTGeometry()

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -28,6 +28,7 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
 			  "EggShapedHyperK_withHPD\n"
                           "nuPRISM\n"
                           "nuPRISM_mPMT\n"
+			  "nuPRISMBeamTest_mPMT\n"
     			  "nuPRISMShort_mPMT\n"
 			  "Cylinder_60x74_3inchmPMT_14perCent\n"
 			  "Cylinder_60x74_3inchmPMT_40perCent\n"
@@ -49,6 +50,7 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
 			   "EggShapedHyperK_withHPD "
                            "nuPRISM "
                            "nuPRISM_mPMT "
+			   "nuPRISMBeamTest_mPMT "
 			   "nuPRISMShort_mPMT "
 			   "Cylinder_60x74_3inchmPMT_14perCent "
 			   "Cylinder_60x74_3inchmPMT_40perCent "
@@ -430,7 +432,10 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
                 } else if ( newValue == "nuPRISM_mPMT") {
 		  WCSimDetector->SetIsNuPrism(true);
 		  WCSimDetector->SetNuPrism_mPMTGeometry();
-                } else if ( newValue == "nuPRISMShort_mPMT") {
+                } else if ( newValue == "nuPRISMBeamTest_mPMT") {
+		WCSimDetector->SetIsNuPrism(true);
+		WCSimDetector->SetNuPrismBeamTest_mPMTGeometry();
+		} else if ( newValue == "nuPRISMShort_mPMT") {
 		  WCSimDetector->SetIsNuPrism(true);
 		  WCSimDetector->SetNuPrismShort_mPMTGeometry();
 		} else

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -433,10 +433,10 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 		  WCSimDetector->SetIsNuPrism(true);
 		  WCSimDetector->SetNuPrism_mPMTGeometry();
                 } else if ( newValue == "nuPRISMBeamTest_mPMT") {
+		WCSimDetector->SetIsNuPrismBeamTest(true); // Jun.04,2020 M.Shinoki
 		WCSimDetector->SetIsNuPrism(true);
 		WCSimDetector->SetNuPrismBeamTest_mPMTGeometry();
 		} else if ( newValue == "nuPRISMShort_mPMT") {
-		WCSimDetector->SetIsNuPrismBeamTest(true); // Jun.04,2020 M.Shinoki
 		  WCSimDetector->SetIsNuPrism(true);
 		  WCSimDetector->SetNuPrismShort_mPMTGeometry();
 		} else

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -436,6 +436,7 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 		WCSimDetector->SetIsNuPrism(true);
 		WCSimDetector->SetNuPrismBeamTest_mPMTGeometry();
 		} else if ( newValue == "nuPRISMShort_mPMT") {
+		WCSimDetector->SetIsNuPrismBeamTest(true); // Jun.04,2020 M.Shinoki
 		  WCSimDetector->SetIsNuPrism(true);
 		  WCSimDetector->SetNuPrismShort_mPMTGeometry();
 		} else


### PR DESCRIPTION
WCTE geometry implemented by @mshinoki and used in WCTE vs IWCD studies such as in [this meeting](http://www-sk.icrr.u-tokyo.ac.jp/indico/event/4360).

Here's [a manual he wrote](https://github.com/nuPRISM/WCSim/files/4726695/WCSim_hknd_manual.pdf) (but from a year ago, not sure if outdated; maybe @kmtsui knows more). We should also version control the fiTQun stuff.

After this is merged, we should probably make a new organization for WCTE, then fork out to there again.