### PR TITLE
Add particle tracking options

### DIFF
--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -11,6 +11,7 @@
 #include "TClonesArray.h"
 #include <string>
 #include <vector>
+#include "TVector3.h"
 //#include <map>
 //#include "G4Transform3D.hh"
 
@@ -114,15 +115,21 @@ private:
   // See jhfNtuple.h for the meaning of these data members:
   Float_t fTruetime;
   Int_t   fPrimaryParentID;
+  Float_t fPhotonStartTime;
+  Float_t fPhotonStartPos[3];
 
 public:
   WCSimRootCherenkovHitTime() {}
   WCSimRootCherenkovHitTime(Float_t truetime,
-			    Int_t   primaryParentID);
+			    Int_t   primaryParentID,
+			    Float_t photonStartTime,
+			    Float_t photonStartPos[3]);
   virtual ~WCSimRootCherenkovHitTime() { }
 
   Float_t   GetTruetime() { return fTruetime;}
   Int_t     GetParentID() { return fPrimaryParentID;}
+  Float_t   GetPhotonStartTime() { return fPhotonStartTime; }
+  Float_t   GetPhotonStartPos(int i) { return (i<3) ? fPhotonStartPos[i] : 0; }
 
   ClassDef(WCSimRootCherenkovHitTime,1)  
 };
@@ -401,7 +408,9 @@ public:
 					   Int_t                mPMTID,
 					   Int_t                mPMT_PMTID,
 					  std::vector<Float_t> truetime,
-					  std::vector<Int_t>   primParID);
+					  std::vector<Int_t>   primParID,
+					  std::vector<Float_t>   photonStartTime,
+                      std::vector<TVector3>   photonStartPos);
   TClonesArray        *GetCherenkovHits() const {return fCherenkovHits;}
   TClonesArray        *GetCherenkovHitTimes() const {return fCherenkovHitTimes;}
 

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -117,19 +117,22 @@ private:
   Int_t   fPrimaryParentID;
   Float_t fPhotonStartTime;
   Float_t fPhotonStartPos[3];
+  Float_t fPhotonEndPos[3];
 
 public:
   WCSimRootCherenkovHitTime() {}
   WCSimRootCherenkovHitTime(Float_t truetime,
 			    Int_t   primaryParentID,
 			    Float_t photonStartTime,
-			    Float_t photonStartPos[3]);
+			    Float_t photonStartPos[3],
+			    Float_t photonEndPos[3]);
   virtual ~WCSimRootCherenkovHitTime() { }
 
   Float_t   GetTruetime() { return fTruetime;}
   Int_t     GetParentID() { return fPrimaryParentID;}
   Float_t   GetPhotonStartTime() { return fPhotonStartTime; }
   Float_t   GetPhotonStartPos(int i) { return (i<3) ? fPhotonStartPos[i] : 0; }
+  Float_t   GetPhotonEndPos(int i) { return (i<3) ? fPhotonEndPos[i] : 0; }
 
   ClassDef(WCSimRootCherenkovHitTime,1)  
 };
@@ -410,7 +413,8 @@ public:
 					  std::vector<Float_t> truetime,
 					  std::vector<Int_t>   primParID,
 					  std::vector<Float_t>   photonStartTime,
-                      std::vector<TVector3>   photonStartPos);
+					  std::vector<TVector3>   photonStartPos,
+					  std::vector<TVector3>   photonEndPos);
   TClonesArray        *GetCherenkovHits() const {return fCherenkovHits;}
   TClonesArray        *GetCherenkovHitTimes() const {return fCherenkovHitTimes;}
 

--- a/include/WCSimTrackInformation.hh
+++ b/include/WCSimTrackInformation.hh
@@ -15,13 +15,19 @@
 // electrons from pion decay are very relevant!!
 class WCSimTrackInformation : public G4VUserTrackInformation {
 private:
-  G4bool saveit; 
+  G4bool saveit;
   G4int  primaryParentID;
+  G4float  photonStartTime;
+  G4ThreeVector  photonStartPos;
 
 public:
   WCSimTrackInformation() : saveit(false), primaryParentID(-99) {}  //TF: initialize to value with NO meaning instead of DN
-  WCSimTrackInformation(const WCSimTrackInformation* aninfo) 
-  { saveit = aninfo->saveit; primaryParentID = aninfo->primaryParentID;}
+  WCSimTrackInformation(const WCSimTrackInformation* aninfo) {
+      saveit = aninfo->saveit;
+      primaryParentID = aninfo->primaryParentID;
+      photonStartTime = aninfo->photonStartTime;
+      photonStartPos = aninfo->photonStartPos;
+  }
   virtual ~WCSimTrackInformation() {}
   WCSimTrackInformation(const G4Track* );
   
@@ -29,7 +35,11 @@ public:
   void WillBeSaved(G4bool choice) { saveit = choice;}
 
   void SetPrimaryParentID(G4int i) { primaryParentID = i;}
+  void SetPhotonStartTime(G4float time) { photonStartTime = time;}
+  void SetPhotonStartPos(const G4ThreeVector &pos) { photonStartPos = pos;}
   G4int GetPrimaryParentID() {return primaryParentID;}
+  G4float GetPhotonStartTime() {return photonStartTime;}
+  G4ThreeVector GetPhotonStartPos() {return photonStartPos;}
 
   inline void *operator new(size_t);
   inline void operator delete(void *aTrackInfo);

--- a/include/WCSimTrackingAction.hh
+++ b/include/WCSimTrackingAction.hh
@@ -21,6 +21,9 @@ class WCSimTrackingAction : public G4UserTrackingAction
 
   void SetFractionChPhotons(G4double fraction){percentageOfCherenkovPhotonsToDraw = fraction;}
   
+  void AddProcess(const G4String &process){ProcessList.insert(process);}
+  void AddParticle(G4int pid){ParticleList.insert(pid);}
+  
 private:
   std::set<G4String> ProcessList;
   std::set<G4int> ParticleList;

--- a/include/WCSimTrackingMessenger.hh
+++ b/include/WCSimTrackingMessenger.hh
@@ -7,6 +7,8 @@
 class G4UIcommand;
 class G4UIdirectory;
 class G4UIcmdWithADouble;
+class G4UIcmdWithAnInteger;
+class G4UIcmdWithAString;
 class WCSimTrackingAction;
 
 class WCSimTrackingMessenger: public G4UImessenger
@@ -23,6 +25,8 @@ private:
 
   G4UIdirectory* WCSimDir;
   G4UIcmdWithADouble* fractionPhotonsToDraw;
+  G4UIcmdWithAnInteger* particleToTrack;
+  G4UIcmdWithAString* processToTrack;
 };
 
 #endif

--- a/include/WCSimWCDigi.hh
+++ b/include/WCSimWCDigi.hh
@@ -70,7 +70,8 @@ private:
   std::map<int, std::vector<int> > fDigiComp;
   std::map<int, G4int>    primaryParentID; ///< Primary parent ID of the Hit (do not use for Digits)
   std::map<int, G4float>    photonStartTime; ///< Primary parent ID of the Hit (do not use for Digits)
-  std::map<int, G4ThreeVector>    photonStartPos; ///< Primary parent ID of the Hit (do not use for Digits)
+  std::map<int, G4ThreeVector>    photonStartPos; ///< Start point of the photon of the Hit (do not use for Digits)
+  std::map<int, G4ThreeVector>    photonEndPos; ///< End point of the photon of the Hit (do not use for Digits)
   
 
   //integrated hit/digit parameters
@@ -93,6 +94,7 @@ public:
   inline void SetParentID(G4int gate, G4int parent) { primaryParentID[gate] = parent; };
   inline void SetPhotonStartTime(G4int gate, G4float time) { photonStartTime[gate] = time; };
   inline void SetPhotonStartPos(G4int gate, const G4ThreeVector &position) { photonStartPos[gate] = position; };
+  inline void SetPhotonEndPos(G4int gate, const G4ThreeVector &position) { photonEndPos[gate] = position; };
 
   // Add a digit number and unique photon number to fDigiComp
   inline void AddPhotonToDigiComposition(int digi_number, int photon_number){
@@ -109,6 +111,7 @@ public:
   inline G4int          GetParentID(int gate)    { return primaryParentID[gate];};
   inline G4float        GetPhotonStartTime(int gate)    { return photonStartTime[gate];};
   inline G4ThreeVector  GetPhotonStartPos(int gate)    { return photonStartPos[gate];};
+  inline G4ThreeVector  GetPhotonEndPos(int gate)    { return photonEndPos[gate];};
   inline G4int          GetTrackID()    { return trackID;};
   inline G4float GetGateTime(int gate) { return TriggerTimes[gate];}
   inline G4int   GetTubeID() {return tubeID;};

--- a/include/WCSimWCDigi.hh
+++ b/include/WCSimWCDigi.hh
@@ -69,6 +69,8 @@ private:
    */
   std::map<int, std::vector<int> > fDigiComp;
   std::map<int, G4int>    primaryParentID; ///< Primary parent ID of the Hit (do not use for Digits)
+  std::map<int, G4float>    photonStartTime; ///< Primary parent ID of the Hit (do not use for Digits)
+  std::map<int, G4ThreeVector>    photonStartPos; ///< Primary parent ID of the Hit (do not use for Digits)
   
 
   //integrated hit/digit parameters
@@ -89,6 +91,8 @@ public:
   inline void SetTime(G4int gate, G4float T)    {time[gate]   = T;};
   inline void SetPreSmearTime(G4int gate, G4float T)    {time_presmear[gate]   = T;};
   inline void SetParentID(G4int gate, G4int parent) { primaryParentID[gate] = parent; };
+  inline void SetPhotonStartTime(G4int gate, G4float time) { photonStartTime[gate] = time; };
+  inline void SetPhotonStartPos(G4int gate, const G4ThreeVector &position) { photonStartPos[gate] = position; };
 
   // Add a digit number and unique photon number to fDigiComp
   inline void AddPhotonToDigiComposition(int digi_number, int photon_number){
@@ -103,6 +107,8 @@ public:
 
 
   inline G4int          GetParentID(int gate)    { return primaryParentID[gate];};
+  inline G4float        GetPhotonStartTime(int gate)    { return photonStartTime[gate];};
+  inline G4ThreeVector  GetPhotonStartPos(int gate)    { return photonStartPos[gate];};
   inline G4int          GetTrackID()    { return trackID;};
   inline G4float GetGateTime(int gate) { return TriggerTimes[gate];}
   inline G4int   GetTubeID() {return tubeID;};

--- a/include/WCSimWCDigi.hh
+++ b/include/WCSimWCDigi.hh
@@ -154,6 +154,8 @@ public:
     float index_time,index_timepresmear,index_pe;
     std::vector<int> index_digicomp;
     int index_primaryparentid;
+    float index_photonstarttime;
+    G4ThreeVector index_photonstartpos;
     for (i = 1; i < (int) time.size(); ++i)
       {
         index_time  = time[i];
@@ -161,11 +163,15 @@ public:
         index_pe = pe[i];
 	index_digicomp = fDigiComp[i];
 	index_primaryparentid = primaryParentID[i];
+	index_photonstarttime = photonStartTime[i];
+	index_photonstartpos = photonStartPos[i];
         for (j = i; j > 0 && time[j-1] > index_time; j--) {
           time[j] = time[j-1];
           pe[j] = pe[j-1];
 	  fDigiComp[j] = fDigiComp[j-1];
 	  primaryParentID[j] = primaryParentID[j-1];
+	  photonStartTime[j] = photonStartTime[j-1];
+	  photonStartPos[j] = photonStartPos[j-1];
           //G4cout <<"swapping "<<time[j-1]<<" "<<index_time<<G4endl;
         }
         
@@ -174,6 +180,8 @@ public:
         pe[j] = index_pe;
 	fDigiComp[j] = index_digicomp;
 	primaryParentID[j] = index_primaryparentid;
+	photonStartTime[j] = index_photonstarttime;
+	photonStartPos[j] = index_photonstartpos;
       }    
   }
   

--- a/include/WCSimWCHit.hh
+++ b/include/WCSimWCHit.hh
@@ -62,8 +62,9 @@ class WCSimWCHit : public G4VHit
   void SetOrientation  (G4ThreeVector xyz)          { orient = xyz; };
   void SetRot          (G4RotationMatrix rotMatrix) { rot = rotMatrix; };
   void SetLogicalVolume(G4LogicalVolume* logV)      { pLogV = logV;}
-  void AddParentID     (G4int primParentID)
-  { primaryParentID.push_back(primParentID); }
+  void AddParentID     (G4int primParentID) { primaryParentID.push_back(primParentID); }
+  void AddPhotonStartTime (G4float photStartTime) { photonStartTime.push_back(photStartTime); }
+  void AddPhotonStartPos  (const G4ThreeVector &photStartPos) { photonStartPos.push_back(photStartPos); }
 
   // This is temporarily used for the drawing scale
   void SetMaxPe(G4int number = 0)  {maxPe   = number;};
@@ -86,6 +87,8 @@ class WCSimWCHit : public G4VHit
   G4int         GetTotalPe()    { return totalPe;};
   G4float       GetTime(int i)  { return time[i];};
   G4int         GetParentID(int i) { return primaryParentID[i];};
+  G4float       GetPhotonStartTime(int i) { return photonStartTime[i];};
+  G4ThreeVector GetPhotonStartPos(int i) { return photonStartPos[i];};
   
   G4LogicalVolume* GetLogicalVolume() {return pLogV;};
 
@@ -162,6 +165,8 @@ class WCSimWCHit : public G4VHit
   G4int                 totalPe;
   std::vector<G4float>  time;
   std::vector<G4int>    primaryParentID;
+  std::vector<G4float>  photonStartTime;
+  std::vector<G4ThreeVector> photonStartPos;
   G4int                 totalPeInGate;
 };
 

--- a/include/WCSimWCHit.hh
+++ b/include/WCSimWCHit.hh
@@ -65,6 +65,7 @@ class WCSimWCHit : public G4VHit
   void AddParentID     (G4int primParentID) { primaryParentID.push_back(primParentID); }
   void AddPhotonStartTime (G4float photStartTime) { photonStartTime.push_back(photStartTime); }
   void AddPhotonStartPos  (const G4ThreeVector &photStartPos) { photonStartPos.push_back(photStartPos); }
+  void AddPhotonEndPos  (const G4ThreeVector &photEndPos) { photonEndPos.push_back(photEndPos); }
 
   // This is temporarily used for the drawing scale
   void SetMaxPe(G4int number = 0)  {maxPe   = number;};
@@ -89,6 +90,7 @@ class WCSimWCHit : public G4VHit
   G4int         GetParentID(int i) { return primaryParentID[i];};
   G4float       GetPhotonStartTime(int i) { return photonStartTime[i];};
   G4ThreeVector GetPhotonStartPos(int i) { return photonStartPos[i];};
+  G4ThreeVector GetPhotonEndPos(int i) { return photonEndPos[i];};
   
   G4LogicalVolume* GetLogicalVolume() {return pLogV;};
 
@@ -167,6 +169,7 @@ class WCSimWCHit : public G4VHit
   std::vector<G4int>    primaryParentID;
   std::vector<G4float>  photonStartTime;
   std::vector<G4ThreeVector> photonStartPos;
+  std::vector<G4ThreeVector> photonEndPos;
   G4int                 totalPeInGate;
 };
 

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -242,6 +242,7 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
 	(*WCHC)[hitIndex]->AddPe(time);
 	(*WCHC)[hitIndex]->AddParentID(0); // Make parent a geantino (whatever that is)
 	(*WCHC)[hitIndex]->AddPhotonStartPos(pos);
+	(*WCHC)[hitIndex]->AddPhotonEndPos(pos);
 	(*WCHC)[hitIndex]->AddPhotonStartTime(time);
       }
     }
@@ -878,10 +879,12 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
     std::vector<int>   primaryParentID;
     std::vector<float> photonStartTime;
     std::vector<TVector3> photonStartPos;
+    std::vector<TVector3> photonEndPos;
     double hit_time_smear, hit_time_true;
     int hit_parentid;
     float hit_photon_starttime;
     TVector3 hit_photon_startpos;
+    TVector3 hit_photon_endpos;
     //loop over the DigitsCollection
     for(int idigi = 0; idigi < WCDC_hits->entries(); idigi++) {
       int digi_tubeid = (*WCDC_hits)[idigi]->GetTubeID();
@@ -895,10 +898,15 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 	        (*WCDC_hits)[idigi]->GetPhotonStartPos(id)[0], 
 	        (*WCDC_hits)[idigi]->GetPhotonStartPos(id)[1], 
 	        (*WCDC_hits)[idigi]->GetPhotonStartPos(id)[2]);
+	hit_photon_endpos = TVector3(
+	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[0],
+	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[1],
+	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[2]);
 	truetime.push_back(hit_time_true);
 	primaryParentID.push_back(hit_parentid);
 	photonStartTime.push_back(hit_photon_starttime);
 	photonStartPos.push_back(hit_photon_startpos);
+	photonEndPos.push_back(hit_photon_endpos);
 #ifdef _SAVE_RAW_HITS_VERBOSE
 	hit_time_smear = (*WCDC_hits)[idigi]->GetTime(id);
 	smeartime.push_back(hit_time_smear);
@@ -923,12 +931,14 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 				      truetime,
 				      primaryParentID,
 				      photonStartTime,
-				      photonStartPos);
+				      photonStartPos,
+				      photonEndPos);
       smeartime.clear();
       truetime.clear();
       primaryParentID.clear();
       photonStartTime.clear();
       photonStartPos.clear();
+      photonEndPos.clear();
     }//idigi
   }//if(WCDC_hits)
 #endif //_SAVE_RAW_HITS

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -229,16 +229,20 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
 	
       }
      
+      const G4ThreeVector &pos = detectorConstructor->GetTubeTransform((*pmtIt)->Get_tubeid()).getTranslation();
       (*WCHC)[hitIndex]->SetTubeID((*pmtIt)->Get_tubeid());
       (*WCHC)[hitIndex]->SetTrackID(0);
       (*WCHC)[hitIndex]->SetEdep(0.);
-      (*WCHC)[hitIndex]->SetPos(detectorConstructor->GetTubeTransform((*pmtIt)->Get_tubeid()).getTranslation());
+      (*WCHC)[hitIndex]->SetPos(pos);
       (*WCHC)[hitIndex]->SetRot(detectorConstructor->GetTubeTransform((*pmtIt)->Get_tubeid()).getRotation());
       
       // Ignore logical volume for now...
       for (int pe = 0; pe < nPoisson; pe++) {
-	(*WCHC)[hitIndex]->AddPe(G4RandGauss::shoot(0.0,10.));
+	G4float time = G4RandGauss::shoot(0.0,10.);
+	(*WCHC)[hitIndex]->AddPe(time);
 	(*WCHC)[hitIndex]->AddParentID(0); // Make parent a geantino (whatever that is)
+	(*WCHC)[hitIndex]->AddPhotonStartPos(pos);
+	(*WCHC)[hitIndex]->AddPhotonStartTime(time);
       }
     }
   }
@@ -872,8 +876,12 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
     wcsimrootevent->SetNumTubesHit(WCDC_hits->entries());
     std::vector<float> truetime, smeartime;
     std::vector<int>   primaryParentID;
+    std::vector<float> photonStartTime;
+    std::vector<TVector3> photonStartPos;
     double hit_time_smear, hit_time_true;
     int hit_parentid;
+    float hit_photon_starttime;
+    TVector3 hit_photon_startpos;
     //loop over the DigitsCollection
     for(int idigi = 0; idigi < WCDC_hits->entries(); idigi++) {
       int digi_tubeid = (*WCDC_hits)[idigi]->GetTubeID();
@@ -882,8 +890,15 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
       for(G4int id = 0; id < (*WCDC_hits)[idigi]->GetTotalPe(); id++){
 	hit_time_true  = (*WCDC_hits)[idigi]->GetPreSmearTime(id);
 	hit_parentid = (*WCDC_hits)[idigi]->GetParentID(id);
+	hit_photon_starttime = (*WCDC_hits)[idigi]->GetPhotonStartTime(id);
+	hit_photon_startpos = TVector3(
+	        (*WCDC_hits)[idigi]->GetPhotonStartPos(id)[0], 
+	        (*WCDC_hits)[idigi]->GetPhotonStartPos(id)[1], 
+	        (*WCDC_hits)[idigi]->GetPhotonStartPos(id)[2]);
 	truetime.push_back(hit_time_true);
 	primaryParentID.push_back(hit_parentid);
+	photonStartTime.push_back(hit_photon_starttime);
+	photonStartPos.push_back(hit_photon_startpos);
 #ifdef _SAVE_RAW_HITS_VERBOSE
 	hit_time_smear = (*WCDC_hits)[idigi]->GetTime(id);
 	smeartime.push_back(hit_time_smear);
@@ -906,10 +921,14 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 				      pmt->Get_mPMTid(),
 				      pmt->Get_mPMT_pmtid(),
 				      truetime,
-				      primaryParentID);
+				      primaryParentID,
+				      photonStartTime,
+				      photonStartPos);
       smeartime.clear();
       truetime.clear();
       primaryParentID.clear();
+      photonStartTime.clear();
+      photonStartPos.clear();
     }//idigi
   }//if(WCDC_hits)
 #endif //_SAVE_RAW_HITS

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -410,7 +410,8 @@ WCSimRootTrack::WCSimRootTrack(Int_t ipnu,
 
 //_____________________________________________________________________________
 
-WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID, Int_t mPMTID, Int_t mPMT_PMTID, std::vector<Float_t> truetime,std::vector<Int_t> primParID)
+WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID, Int_t mPMTID, Int_t mPMT_PMTID, std::vector<Float_t> truetime,
+        std::vector<Int_t> primParID, std::vector<Float_t> photonStartTime, std::vector<TVector3> photonStartPos)
 {
   // Add a new Cherenkov hit to the list of Cherenkov hits
   TClonesArray &cherenkovhittimes = *fCherenkovHitTimes;
@@ -418,9 +419,10 @@ WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID, Int_t mPM
   for (unsigned int i =0;i<truetime.size();i++)
   {
     fCherenkovHitCounter++;
-
+    Float_t position[3];
+    for(int j=0; j<3; j++) position[j] = photonStartPos[i][j];
     WCSimRootCherenkovHitTime *cherenkovhittime = 
-      new(cherenkovhittimes[fNcherenkovhittimes++]) WCSimRootCherenkovHitTime(truetime[i],primParID[i]);
+      new(cherenkovhittimes[fNcherenkovhittimes++]) WCSimRootCherenkovHitTime(truetime[i],primParID[i], photonStartTime[i], position);
   }
 
   Int_t WC_Index[2];
@@ -466,11 +468,15 @@ WCSimRootCherenkovHit::WCSimRootCherenkovHit(Int_t tubeID,
 }
 
 WCSimRootCherenkovHitTime::WCSimRootCherenkovHitTime(Float_t truetime,
-						     Int_t primParID)
+						     Int_t primParID, Float_t photonStartTime, Float_t photonStartPos[3])
 {
   // Create a WCSimRootCherenkovHit object and fill it with stuff
     fTruetime        = truetime; 
     fPrimaryParentID = primParID;
+    fPhotonStartTime = photonStartTime;
+    for (int i=0;i<3;i++) {
+        fPhotonStartPos[i] = photonStartPos[i];
+    }
 }
 
 //_____________________________________________________________________________

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -411,7 +411,7 @@ WCSimRootTrack::WCSimRootTrack(Int_t ipnu,
 //_____________________________________________________________________________
 
 WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID, Int_t mPMTID, Int_t mPMT_PMTID, std::vector<Float_t> truetime,
-        std::vector<Int_t> primParID, std::vector<Float_t> photonStartTime, std::vector<TVector3> photonStartPos)
+        std::vector<Int_t> primParID, std::vector<Float_t> photonStartTime, std::vector<TVector3> photonStartPos, std::vector<TVector3> photonEndPos)
 {
   // Add a new Cherenkov hit to the list of Cherenkov hits
   TClonesArray &cherenkovhittimes = *fCherenkovHitTimes;
@@ -419,10 +419,14 @@ WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID, Int_t mPM
   for (unsigned int i =0;i<truetime.size();i++)
   {
     fCherenkovHitCounter++;
-    Float_t position[3];
-    for(int j=0; j<3; j++) position[j] = photonStartPos[i][j];
+    Float_t startPos[3];
+    Float_t endPos[3];
+    for(int j=0; j<3; j++){
+      startPos[j] = photonStartPos[i][j];
+      endPos[j] = photonEndPos[i][j];
+    }
     WCSimRootCherenkovHitTime *cherenkovhittime = 
-      new(cherenkovhittimes[fNcherenkovhittimes++]) WCSimRootCherenkovHitTime(truetime[i],primParID[i], photonStartTime[i], position);
+      new(cherenkovhittimes[fNcherenkovhittimes++]) WCSimRootCherenkovHitTime(truetime[i],primParID[i], photonStartTime[i], startPos, endPos);
   }
 
   Int_t WC_Index[2];
@@ -467,8 +471,8 @@ WCSimRootCherenkovHit::WCSimRootCherenkovHit(Int_t tubeID,
   fTotalPe[1] = totalPe[1];
 }
 
-WCSimRootCherenkovHitTime::WCSimRootCherenkovHitTime(Float_t truetime,
-						     Int_t primParID, Float_t photonStartTime, Float_t photonStartPos[3])
+WCSimRootCherenkovHitTime::WCSimRootCherenkovHitTime(Float_t truetime, Int_t primParID,
+						     Float_t photonStartTime, Float_t photonStartPos[3], Float_t photonEndPos[3])
 {
   // Create a WCSimRootCherenkovHit object and fill it with stuff
     fTruetime        = truetime; 
@@ -476,6 +480,7 @@ WCSimRootCherenkovHitTime::WCSimRootCherenkovHitTime(Float_t truetime,
     fPhotonStartTime = photonStartTime;
     for (int i=0;i<3;i++) {
         fPhotonStartPos[i] = photonStartPos[i];
+        fPhotonEndPos[i] = photonEndPos[i];
     }
 }
 

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -134,8 +134,8 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
     //TF: crucial bugfix: I want this for all tracks that I save to match Ch hits with tracks that can
     // produce Cherenkov light.
     else
-      anInfo->SetPrimaryParentID(aTrack->GetTrackID());   
-  }
+      anInfo->SetPrimaryParentID(aTrack->GetTrackID());
+    }
   else {
     anInfo->WillBeSaved(false);
   }
@@ -154,6 +154,10 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
       for(size_t i=0;i<nSeco;i++)
       { 
 	WCSimTrackInformation* infoSec = new WCSimTrackInformation(anInfo);
+	if(anInfo->isSaved()){ // Parent is primary, so we want start pos & time of this secondary
+        infoSec->SetPhotonStartTime((*secondaries)[i]->GetGlobalTime());
+        infoSec->SetPhotonStartPos((*secondaries)[i]->GetPosition());
+	}
 	infoSec->WillBeSaved(false); // ADDED BY MFECHNER, temporary, 30/8/06
 	(*secondaries)[i]->SetUserInformation(infoSec);
       }

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -29,10 +29,6 @@ WCSimTrackingAction::WCSimTrackingAction()
   ParticleList.insert(-321); // kaon-
   ParticleList.insert(311); // kaon0
   ParticleList.insert(-311); // kaon0 bar
-  ParticleList.insert(11); // e-
-  ParticleList.insert(-11); // e+
-  ParticleList.insert(13); // mu-
-  ParticleList.insert(-13); // mu+
   // don't put gammas there or there'll be too many
 
   //TF: add protons and neutrons

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -29,6 +29,10 @@ WCSimTrackingAction::WCSimTrackingAction()
   ParticleList.insert(-321); // kaon-
   ParticleList.insert(311); // kaon0
   ParticleList.insert(-311); // kaon0 bar
+  ParticleList.insert(11); // e-
+  ParticleList.insert(-11); // e+
+  ParticleList.insert(13); // mu-
+  ParticleList.insert(-13); // mu+
   // don't put gammas there or there'll be too many
 
   //TF: add protons and neutrons

--- a/src/WCSimTrackingMessenger.cc
+++ b/src/WCSimTrackingMessenger.cc
@@ -24,7 +24,7 @@ WCSimTrackingMessenger::WCSimTrackingMessenger(WCSimTrackingAction* trackAction)
   particleToTrack->SetGuidance("Command to track all particles of given type");
   particleToTrack->SetParameterName("particleToTrack",false);
 
-  processToTrack = new G4UIcmdWithAString("/Tracking/trackParticle",this);
+  processToTrack = new G4UIcmdWithAString("/Tracking/trackProcess",this);
   processToTrack->SetGuidance("Command to track all particles created by given process");
   processToTrack->SetParameterName("processToTrack",false);
 

--- a/src/WCSimTrackingMessenger.cc
+++ b/src/WCSimTrackingMessenger.cc
@@ -6,6 +6,7 @@
 #include "G4UIcmdWithADoubleAndUnit.hh"
 #include "G4UIcmdWithADouble.hh"
 #include "G4UIcmdWithAnInteger.hh"
+#include "G4UIcmdWithAString.hh"
 
 WCSimTrackingMessenger::WCSimTrackingMessenger(WCSimTrackingAction* trackAction)
   : myTracking(trackAction)
@@ -18,6 +19,14 @@ WCSimTrackingMessenger::WCSimTrackingMessenger(WCSimTrackingAction* trackAction)
   fractionPhotonsToDraw->SetGuidance("Command to change the fraction of Optical Photons to track");
   fractionPhotonsToDraw->SetParameterName("fractionOpticalPhotonsToDraw",true);
   fractionPhotonsToDraw->SetDefaultValue(0.0);
+
+  particleToTrack = new G4UIcmdWithAnInteger("Tracking/trackParticle",this);
+  particleToTrack->SetGuidance("Command to track all particles of given type");
+  particleToTrack->SetParameterName("particleToTrack",false);
+
+  processToTrack = new G4UIcmdWithAString("Tracking/trackParticle",this);
+  processToTrack->SetGuidance("Command to track all particles created by given process");
+  processToTrack->SetParameterName("processToTrack",false);
 
 }
 
@@ -38,5 +47,15 @@ void WCSimTrackingMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
     G4cout << "WARNING: Recommended to not save to root when this is > 0.0 % " << G4endl;
     G4cout << "=======================================================================================. " << G4endl;
   }
+  else if(command == particleToTrack){
+    G4int pid = particleToTrack->GetNewIntValue(newValue);
+    myTracking->AddParticle(pid);
+    G4cout << "Tracking all particles with PID = " << pid << G4endl;
+  }
+  else if(command == processToTrack){
+    myTracking->AddProcess(newValue);
+    G4cout << "Tracking all particles created by the " << newValue << " process" << G4endl;
+  }
+  
 
 }

--- a/src/WCSimTrackingMessenger.cc
+++ b/src/WCSimTrackingMessenger.cc
@@ -20,11 +20,11 @@ WCSimTrackingMessenger::WCSimTrackingMessenger(WCSimTrackingAction* trackAction)
   fractionPhotonsToDraw->SetParameterName("fractionOpticalPhotonsToDraw",true);
   fractionPhotonsToDraw->SetDefaultValue(0.0);
 
-  particleToTrack = new G4UIcmdWithAnInteger("Tracking/trackParticle",this);
+  particleToTrack = new G4UIcmdWithAnInteger("/Tracking/trackParticle",this);
   particleToTrack->SetGuidance("Command to track all particles of given type");
   particleToTrack->SetParameterName("particleToTrack",false);
 
-  processToTrack = new G4UIcmdWithAString("Tracking/trackParticle",this);
+  processToTrack = new G4UIcmdWithAString("/Tracking/trackParticle",this);
   processToTrack->SetGuidance("Command to track all particles created by given process");
   processToTrack->SetParameterName("processToTrack",false);
 

--- a/src/WCSimWCAddDarkNoise.cc
+++ b/src/WCSimWCAddDarkNoise.cc
@@ -194,6 +194,8 @@ void WCSimWCAddDarkNoise::AddDarkNoiseBeforeDigi(WCSimWCDigitsCollection* WCHCPM
 	    ahit->SetOrientation(pmt_orientation);
 	    ahit->SetPos(pmt_position);
 	    ahit->SetTime(PMTindex[noise_pmt],current_time);
+	    ahit->SetPhotonStartTime(PMTindex[noise_pmt],current_time);
+	    ahit->SetPhotonStartPos(PMTindex[noise_pmt], pmt_position);
 	    ahit->SetPreSmearTime(PMTindex[noise_pmt],current_time); //presmear==postsmear for dark noise
 	    pe = WCPMT->rn1pe();
 	    ahit->SetPe(PMTindex[noise_pmt],pe);
@@ -215,6 +217,8 @@ void WCSimWCAddDarkNoise::AddDarkNoiseBeforeDigi(WCSimWCDigitsCollection* WCHCPM
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetTime(PMTindex[noise_pmt],current_time);
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPreSmearTime(PMTindex[noise_pmt],current_time); //presmear==postsmear for dark noise
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetParentID(PMTindex[noise_pmt],-1);
+      (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartTime(PMTindex[noise_pmt],current_time);
+      (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartPos(PMTindex[noise_pmt],(*WCHCPMT)[ list[noise_pmt]-1 ]->GetPos());
 	  PMTindex[noise_pmt]++;
 #ifdef WCSIMWCADDDARKNOISE_VERBOSE
 	  if(noise_pmt < NPMTS_VERBOSE)

--- a/src/WCSimWCAddDarkNoise.cc
+++ b/src/WCSimWCAddDarkNoise.cc
@@ -196,6 +196,7 @@ void WCSimWCAddDarkNoise::AddDarkNoiseBeforeDigi(WCSimWCDigitsCollection* WCHCPM
 	    ahit->SetTime(PMTindex[noise_pmt],current_time);
 	    ahit->SetPhotonStartTime(PMTindex[noise_pmt],current_time);
 	    ahit->SetPhotonStartPos(PMTindex[noise_pmt], pmt_position);
+	    ahit->SetPhotonEndPos(PMTindex[noise_pmt], pmt_position);
 	    ahit->SetPreSmearTime(PMTindex[noise_pmt],current_time); //presmear==postsmear for dark noise
 	    pe = WCPMT->rn1pe();
 	    ahit->SetPe(PMTindex[noise_pmt],pe);
@@ -217,8 +218,9 @@ void WCSimWCAddDarkNoise::AddDarkNoiseBeforeDigi(WCSimWCDigitsCollection* WCHCPM
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetTime(PMTindex[noise_pmt],current_time);
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPreSmearTime(PMTindex[noise_pmt],current_time); //presmear==postsmear for dark noise
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetParentID(PMTindex[noise_pmt],-1);
-      (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartTime(PMTindex[noise_pmt],current_time);
-      (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartPos(PMTindex[noise_pmt],(*WCHCPMT)[ list[noise_pmt]-1 ]->GetPos());
+	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartTime(PMTindex[noise_pmt],current_time);
+	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartPos(PMTindex[noise_pmt],(*WCHCPMT)[ list[noise_pmt]-1 ]->GetPos());
+	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonEndPos(PMTindex[noise_pmt],(*WCHCPMT)[ list[noise_pmt]-1 ]->GetPos());
 	  PMTindex[noise_pmt]++;
 #ifdef WCSIMWCADDDARKNOISE_VERBOSE
 	  if(noise_pmt < NPMTS_VERBOSE)

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -134,8 +134,10 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	    time_true = (*WCHC)[i]->GetTime(ip);
 	    time_PMT  = time_true; //currently no PMT time smearing applied
 	    peSmeared = rn1pe();
-	    int parent_id = (*WCHC)[i]->GetParentID(ip);
-
+        int parent_id = (*WCHC)[i]->GetParentID(ip);
+        float photon_starttime = (*WCHC)[i]->GetPhotonStartTime(ip);
+        G4ThreeVector photon_startpos = (*WCHC)[i]->GetPhotonStartPos(ip);
+        
 	    if ( DigiHitMapPMT[tube] == 0) {
 	      WCSimWCDigi* Digi = new WCSimWCDigi();
 	      Digi->SetLogicalVolume((*WCHC)[0]->GetLogicalVolume());
@@ -148,6 +150,8 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	      Digi->SetTrackID(track_id);
 	      Digi->SetPreSmearTime(ip,time_true);
 	      Digi->SetParentID(ip,parent_id);
+	      Digi->SetPhotonStartTime(ip,photon_starttime);
+	      Digi->SetPhotonStartPos(ip,photon_startpos);
 	      DigiHitMapPMT[tube] = DigitsCollection->insert(Digi);
 	    }	
 	    else {
@@ -161,6 +165,8 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetTrackID(track_id);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPreSmearTime(ip,time_true);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetParentID(ip,parent_id);
+          (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonStartTime(ip,photon_starttime);
+          (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonStartPos(ip,photon_startpos);
 	    }
       
 	  } // Loop over hits in each PMT

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -134,10 +134,11 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	    time_true = (*WCHC)[i]->GetTime(ip);
 	    time_PMT  = time_true; //currently no PMT time smearing applied
 	    peSmeared = rn1pe();
-        int parent_id = (*WCHC)[i]->GetParentID(ip);
-        float photon_starttime = (*WCHC)[i]->GetPhotonStartTime(ip);
-        G4ThreeVector photon_startpos = (*WCHC)[i]->GetPhotonStartPos(ip);
-        
+	    int parent_id = (*WCHC)[i]->GetParentID(ip);
+	    float photon_starttime = (*WCHC)[i]->GetPhotonStartTime(ip);
+	    G4ThreeVector photon_startpos = (*WCHC)[i]->GetPhotonStartPos(ip);
+	    G4ThreeVector photon_endpos = (*WCHC)[i]->GetPhotonEndPos(ip);
+	    
 	    if ( DigiHitMapPMT[tube] == 0) {
 	      WCSimWCDigi* Digi = new WCSimWCDigi();
 	      Digi->SetLogicalVolume((*WCHC)[0]->GetLogicalVolume());
@@ -152,6 +153,7 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	      Digi->SetParentID(ip,parent_id);
 	      Digi->SetPhotonStartTime(ip,photon_starttime);
 	      Digi->SetPhotonStartPos(ip,photon_startpos);
+	      Digi->SetPhotonEndPos(ip,photon_endpos);
 	      DigiHitMapPMT[tube] = DigitsCollection->insert(Digi);
 	    }	
 	    else {
@@ -165,8 +167,9 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetTrackID(track_id);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPreSmearTime(ip,time_true);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetParentID(ip,parent_id);
-          (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonStartTime(ip,photon_starttime);
-          (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonStartPos(ip,photon_startpos);
+	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonStartTime(ip,photon_starttime);
+	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonStartPos(ip,photon_startpos);
+	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonEndPos(ip,photon_endpos);
 	    }
       
 	  } // Loop over hits in each PMT

--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -230,6 +230,7 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddParentID(primParentID);
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartTime(photonStartTime);
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartPos(photonStartPos);
+	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonEndPos(worldPosition);
 	   
 	   //     if ( particleDefinition != G4OpticalPhoton::OpticalPhotonDefinition() )
 	   //       newHit->Print();
@@ -240,6 +241,7 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddParentID(primParentID);
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartTime(photonStartTime);
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartPos(photonStartPos);
+	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonEndPos(worldPosition);
 	 
        }
      }

--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -84,11 +84,19 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
     = (WCSimTrackInformation*)(aStep->GetTrack()->GetUserInformation());
   
   G4int primParentID = -1;
-  if (trackinfo)
+  G4float photonStartTime;
+  G4ThreeVector photonStartPos;
+  if (trackinfo) {
     //Skip secondaries and match to mother process, eg. muon, decay particle, gamma from pi0/nCapture.
-    primParentID = trackinfo->GetPrimaryParentID();  //!= ParentID. 
-  else // if there is no trackinfo, then it is a primary particle!
-    primParentID = aStep->GetTrack()->GetTrackID();    
+    primParentID = trackinfo->GetPrimaryParentID();  //!= ParentID.
+    photonStartTime = trackinfo->GetPhotonStartTime();
+    photonStartPos = trackinfo->GetPhotonStartPos();
+  }
+  else { // if there is no trackinfo, then it is a primary particle!
+    primParentID = aStep->GetTrack()->GetTrackID();
+    photonStartTime = aStep->GetTrack()->GetGlobalTime();
+    photonStartPos = aStep->GetTrack()->GetVertexPosition();
+  }
 
 
   G4int    trackID           = aStep->GetTrack()->GetTrackID();
@@ -220,6 +228,8 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 	   PMTHitMap[replicaNumber] = hitsCollection->insert( newHit );
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPe(hitTime);
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddParentID(primParentID);
+	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartTime(photonStartTime);
+	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartPos(photonStartPos);
 	   
 	   //     if ( particleDefinition != G4OpticalPhoton::OpticalPhotonDefinition() )
 	   //       newHit->Print();
@@ -228,6 +238,8 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
        else {
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPe(hitTime);
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddParentID(primParentID);
+	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartTime(photonStartTime);
+	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartPos(photonStartPos);
 	 
        }
      }


### PR DESCRIPTION
Adds the ability to choose additional particle types whose tracks should be stored in WCSim's truth information. e.g.:
/Tracking/trackParticle [PDG code]
to track all particles with given PDG particle ID code, or
/Tracking/trackProcess [G4 process name]
to track all particles produced by a particular Geant4 process.
Also adds extra truth info about true hits: the start and end point positions of each Cherenkov photon that produces a true hit.
Edit: originally I said that the parent track of hits was also added, but after checking I realised this was not new but actually already existed.