### PR TITLE
Add git hash to output settings tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,8 @@ else()
     set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -std=c++0x")
 endif()
 
-
+# Set flag for git version to be used as c++ preprocessor macro
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGIT_HASH=\"\\\"`git describe --always --long --tags --dirty`\\\"\"")
 
 add_executable(WCSim WCSim.cc ${sources} ${headers})
 target_link_libraries(WCSim ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} WCSimRoot Tree)  #add profiler to use gperftools
@@ -104,7 +105,6 @@ set(WCSIM_SCRIPTS
   macros/visOGLSX.mac
   macros/visOGLQT.mac
   macros/visRayTracer.mac
-  macros/mPMT.mac
   macros/mPMT_nuPrism1.mac
   macros/mPMT_nuPrism2.mac
   macros/tuning_parameters.mac

--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -47,6 +47,9 @@ else
 DOXYGEN_EXISTS = 0
 endif
 
+# Set flag for git version to be used as c++ preprocessor macro
+CPPFLAGS += -DGIT_HASH=\"$(shell git describe --always --long --tags --dirty)\"
+
 .PHONY: all
 all: rootcint lib bin shared libWCSim.a
 

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -83,7 +83,10 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* /*aRun*/)
     fSettingsOutputTree->Branch("WCDetCentre", WCDetCentre, "WCDetCentre[3]/F");
     fSettingsOutputTree->Branch("WCDetRadius", &WCDetRadius, "WCDetRadius/F");
     fSettingsOutputTree->Branch("WCDetHeight", &WCDetHeight, "WCDetHeight/F");
- 
+#ifdef GIT_HASH
+    const char* gitHash = GIT_HASH;
+    fSettingsOutputTree->Branch("GitHash", (void*)gitHash, "GetHash/C");
+#endif
   }      
 
   if(useTimer) {


### PR DESCRIPTION
Adds the describe of the current state of git repository (version/tag, plus latest commit hash, plus '-dirty' if the repository has changed since last commit) at compile time to be stored in the Settings tree of the output root file.
(also fixed cmake compilation that was broken due to check for mPMT macro that has not existed for some time)