### PR TITLE
Add tracking of photon start and end directions for true hits

### DIFF
--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -118,6 +118,8 @@ private:
   Float_t fPhotonStartTime;
   Float_t fPhotonStartPos[3];
   Float_t fPhotonEndPos[3];
+  Float_t fPhotonStartDir[3];
+  Float_t fPhotonEndDir[3];
 
 public:
   WCSimRootCherenkovHitTime() {}
@@ -125,7 +127,9 @@ public:
 			    Int_t   primaryParentID,
 			    Float_t photonStartTime,
 			    Float_t photonStartPos[3],
-			    Float_t photonEndPos[3]);
+			    Float_t photonEndPos[3],
+			    Float_t photonStartDir[3],
+			    Float_t photonEndDir[3]);
   virtual ~WCSimRootCherenkovHitTime() { }
 
   Float_t   GetTruetime() { return fTruetime;}
@@ -133,6 +137,8 @@ public:
   Float_t   GetPhotonStartTime() { return fPhotonStartTime; }
   Float_t   GetPhotonStartPos(int i) { return (i<3) ? fPhotonStartPos[i] : 0; }
   Float_t   GetPhotonEndPos(int i) { return (i<3) ? fPhotonEndPos[i] : 0; }
+  Float_t   GetPhotonStartDir(int i) { return (i<3) ? fPhotonStartDir[i] : 0; }
+  Float_t   GetPhotonEndDir(int i) { return (i<3) ? fPhotonEndDir[i] : 0; }
 
   ClassDef(WCSimRootCherenkovHitTime,1)  
 };
@@ -414,7 +420,9 @@ public:
 					  std::vector<Int_t>   primParID,
 					  std::vector<Float_t>   photonStartTime,
 					  std::vector<TVector3>   photonStartPos,
-					  std::vector<TVector3>   photonEndPos);
+					  std::vector<TVector3>   photonEndPos,
+					  std::vector<TVector3>   photonStartDir,
+					  std::vector<TVector3>   photonEndDir);
   TClonesArray        *GetCherenkovHits() const {return fCherenkovHits;}
   TClonesArray        *GetCherenkovHitTimes() const {return fCherenkovHitTimes;}
 

--- a/include/WCSimTrackInformation.hh
+++ b/include/WCSimTrackInformation.hh
@@ -19,6 +19,7 @@ private:
   G4int  primaryParentID;
   G4float  photonStartTime;
   G4ThreeVector  photonStartPos;
+  G4ThreeVector  photonStartDir;
 
 public:
   WCSimTrackInformation() : saveit(false), primaryParentID(-99) {}  //TF: initialize to value with NO meaning instead of DN
@@ -27,6 +28,7 @@ public:
       primaryParentID = aninfo->primaryParentID;
       photonStartTime = aninfo->photonStartTime;
       photonStartPos = aninfo->photonStartPos;
+      photonStartDir = aninfo->photonStartDir;
   }
   virtual ~WCSimTrackInformation() {}
   WCSimTrackInformation(const G4Track* );
@@ -37,9 +39,11 @@ public:
   void SetPrimaryParentID(G4int i) { primaryParentID = i;}
   void SetPhotonStartTime(G4float time) { photonStartTime = time;}
   void SetPhotonStartPos(const G4ThreeVector &pos) { photonStartPos = pos;}
+  void SetPhotonStartDir(const G4ThreeVector &dir) { photonStartDir = dir;}
   G4int GetPrimaryParentID() {return primaryParentID;}
   G4float GetPhotonStartTime() {return photonStartTime;}
   G4ThreeVector GetPhotonStartPos() {return photonStartPos;}
+  G4ThreeVector GetPhotonStartDir() {return photonStartDir;}
 
   inline void *operator new(size_t);
   inline void operator delete(void *aTrackInfo);

--- a/include/WCSimWCDigi.hh
+++ b/include/WCSimWCDigi.hh
@@ -159,6 +159,7 @@ public:
     int index_primaryparentid;
     float index_photonstarttime;
     G4ThreeVector index_photonstartpos;
+    G4ThreeVector index_photonendpos;
     for (i = 1; i < (int) time.size(); ++i)
       {
         index_time  = time[i];
@@ -168,6 +169,7 @@ public:
 	index_primaryparentid = primaryParentID[i];
 	index_photonstarttime = photonStartTime[i];
 	index_photonstartpos = photonStartPos[i];
+	index_photonendpos = photonEndPos[i];
         for (j = i; j > 0 && time[j-1] > index_time; j--) {
           time[j] = time[j-1];
           pe[j] = pe[j-1];
@@ -175,6 +177,7 @@ public:
 	  primaryParentID[j] = primaryParentID[j-1];
 	  photonStartTime[j] = photonStartTime[j-1];
 	  photonStartPos[j] = photonStartPos[j-1];
+	  photonEndPos[j] = photonEndPos[j-1];
           //G4cout <<"swapping "<<time[j-1]<<" "<<index_time<<G4endl;
         }
         
@@ -185,6 +188,7 @@ public:
 	primaryParentID[j] = index_primaryparentid;
 	photonStartTime[j] = index_photonstarttime;
 	photonStartPos[j] = index_photonstartpos;
+	photonEndPos[j] = index_photonendpos;
       }    
   }
   

--- a/include/WCSimWCDigi.hh
+++ b/include/WCSimWCDigi.hh
@@ -72,6 +72,8 @@ private:
   std::map<int, G4float>    photonStartTime; ///< Primary parent ID of the Hit (do not use for Digits)
   std::map<int, G4ThreeVector>    photonStartPos; ///< Start point of the photon of the Hit (do not use for Digits)
   std::map<int, G4ThreeVector>    photonEndPos; ///< End point of the photon of the Hit (do not use for Digits)
+  std::map<int, G4ThreeVector>    photonStartDir; ///< Start dir of the photon of the Hit (do not use for Digits)
+  std::map<int, G4ThreeVector>    photonEndDir; ///< End dir of the photon of the Hit (do not use for Digits)
   
 
   //integrated hit/digit parameters
@@ -95,6 +97,8 @@ public:
   inline void SetPhotonStartTime(G4int gate, G4float time) { photonStartTime[gate] = time; };
   inline void SetPhotonStartPos(G4int gate, const G4ThreeVector &position) { photonStartPos[gate] = position; };
   inline void SetPhotonEndPos(G4int gate, const G4ThreeVector &position) { photonEndPos[gate] = position; };
+  inline void SetPhotonStartDir(G4int gate, const G4ThreeVector &direction) { photonStartDir[gate] = direction; };
+  inline void SetPhotonEndDir(G4int gate, const G4ThreeVector &direction) { photonEndDir[gate] = direction; };
 
   // Add a digit number and unique photon number to fDigiComp
   inline void AddPhotonToDigiComposition(int digi_number, int photon_number){
@@ -112,6 +116,8 @@ public:
   inline G4float        GetPhotonStartTime(int gate)    { return photonStartTime[gate];};
   inline G4ThreeVector  GetPhotonStartPos(int gate)    { return photonStartPos[gate];};
   inline G4ThreeVector  GetPhotonEndPos(int gate)    { return photonEndPos[gate];};
+  inline G4ThreeVector  GetPhotonStartDir(int gate)    { return photonStartDir[gate];};
+  inline G4ThreeVector  GetPhotonEndDir(int gate)    { return photonEndDir[gate];};
   inline G4int          GetTrackID()    { return trackID;};
   inline G4float GetGateTime(int gate) { return TriggerTimes[gate];}
   inline G4int   GetTubeID() {return tubeID;};
@@ -160,6 +166,8 @@ public:
     float index_photonstarttime;
     G4ThreeVector index_photonstartpos;
     G4ThreeVector index_photonendpos;
+    G4ThreeVector index_photonstartdir;
+    G4ThreeVector index_photonenddir;
     for (i = 1; i < (int) time.size(); ++i)
       {
         index_time  = time[i];
@@ -170,6 +178,8 @@ public:
 	index_photonstarttime = photonStartTime[i];
 	index_photonstartpos = photonStartPos[i];
 	index_photonendpos = photonEndPos[i];
+	index_photonstartdir = photonStartDir[i];
+	index_photonenddir = photonEndDir[i];
         for (j = i; j > 0 && time[j-1] > index_time; j--) {
           time[j] = time[j-1];
           pe[j] = pe[j-1];
@@ -178,6 +188,8 @@ public:
 	  photonStartTime[j] = photonStartTime[j-1];
 	  photonStartPos[j] = photonStartPos[j-1];
 	  photonEndPos[j] = photonEndPos[j-1];
+	  photonStartDir[j] = photonStartDir[j-1];
+	  photonEndDir[j] = photonEndDir[j-1];
           //G4cout <<"swapping "<<time[j-1]<<" "<<index_time<<G4endl;
         }
         
@@ -189,6 +201,8 @@ public:
 	photonStartTime[j] = index_photonstarttime;
 	photonStartPos[j] = index_photonstartpos;
 	photonEndPos[j] = index_photonendpos;
+	photonStartDir[j] = index_photonstartdir;
+	photonEndDir[j] = index_photonenddir;
       }    
   }
   

--- a/include/WCSimWCHit.hh
+++ b/include/WCSimWCHit.hh
@@ -66,6 +66,8 @@ class WCSimWCHit : public G4VHit
   void AddPhotonStartTime (G4float photStartTime) { photonStartTime.push_back(photStartTime); }
   void AddPhotonStartPos  (const G4ThreeVector &photStartPos) { photonStartPos.push_back(photStartPos); }
   void AddPhotonEndPos  (const G4ThreeVector &photEndPos) { photonEndPos.push_back(photEndPos); }
+  void AddPhotonStartDir  (const G4ThreeVector &photStartDir) { photonStartDir.push_back(photStartDir); }
+  void AddPhotonEndDir  (const G4ThreeVector &photEndDir) { photonEndDir.push_back(photEndDir); }
 
   // This is temporarily used for the drawing scale
   void SetMaxPe(G4int number = 0)  {maxPe   = number;};
@@ -91,6 +93,8 @@ class WCSimWCHit : public G4VHit
   G4float       GetPhotonStartTime(int i) { return photonStartTime[i];};
   G4ThreeVector GetPhotonStartPos(int i) { return photonStartPos[i];};
   G4ThreeVector GetPhotonEndPos(int i) { return photonEndPos[i];};
+  G4ThreeVector GetPhotonStartDir(int i) { return photonStartDir[i];};
+  G4ThreeVector GetPhotonEndDir(int i) { return photonEndDir[i];};
   
   G4LogicalVolume* GetLogicalVolume() {return pLogV;};
 
@@ -170,6 +174,8 @@ class WCSimWCHit : public G4VHit
   std::vector<G4float>  photonStartTime;
   std::vector<G4ThreeVector> photonStartPos;
   std::vector<G4ThreeVector> photonEndPos;
+  std::vector<G4ThreeVector> photonStartDir;
+  std::vector<G4ThreeVector> photonEndDir;
   G4int                 totalPeInGate;
 };
 

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -239,10 +239,13 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
       // Ignore logical volume for now...
       for (int pe = 0; pe < nPoisson; pe++) {
 	G4float time = G4RandGauss::shoot(0.0,10.);
+	G4ThreeVector dir(0, 0, 0);
 	(*WCHC)[hitIndex]->AddPe(time);
 	(*WCHC)[hitIndex]->AddParentID(0); // Make parent a geantino (whatever that is)
 	(*WCHC)[hitIndex]->AddPhotonStartPos(pos);
 	(*WCHC)[hitIndex]->AddPhotonEndPos(pos);
+	(*WCHC)[hitIndex]->AddPhotonStartDir(dir);
+	(*WCHC)[hitIndex]->AddPhotonEndDir(dir);
 	(*WCHC)[hitIndex]->AddPhotonStartTime(time);
       }
     }
@@ -880,11 +883,15 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
     std::vector<float> photonStartTime;
     std::vector<TVector3> photonStartPos;
     std::vector<TVector3> photonEndPos;
+    std::vector<TVector3> photonStartDir;
+    std::vector<TVector3> photonEndDir;
     double hit_time_smear, hit_time_true;
     int hit_parentid;
     float hit_photon_starttime;
     TVector3 hit_photon_startpos;
     TVector3 hit_photon_endpos;
+    TVector3 hit_photon_startdir;
+    TVector3 hit_photon_enddir;
     //loop over the DigitsCollection
     for(int idigi = 0; idigi < WCDC_hits->entries(); idigi++) {
       int digi_tubeid = (*WCDC_hits)[idigi]->GetTubeID();
@@ -902,11 +909,21 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[0],
 	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[1],
 	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[2]);
+	hit_photon_startdir = TVector3(
+	        (*WCDC_hits)[idigi]->GetPhotonStartDir(id)[0], 
+	        (*WCDC_hits)[idigi]->GetPhotonStartDir(id)[1], 
+	        (*WCDC_hits)[idigi]->GetPhotonStartDir(id)[2]);
+	hit_photon_enddir = TVector3(
+	        (*WCDC_hits)[idigi]->GetPhotonEndDir(id)[0],
+	        (*WCDC_hits)[idigi]->GetPhotonEndDir(id)[1],
+	        (*WCDC_hits)[idigi]->GetPhotonEndDir(id)[2]);
 	truetime.push_back(hit_time_true);
 	primaryParentID.push_back(hit_parentid);
 	photonStartTime.push_back(hit_photon_starttime);
 	photonStartPos.push_back(hit_photon_startpos);
 	photonEndPos.push_back(hit_photon_endpos);
+	photonStartDir.push_back(hit_photon_startdir);
+	photonEndDir.push_back(hit_photon_enddir);
 #ifdef _SAVE_RAW_HITS_VERBOSE
 	hit_time_smear = (*WCDC_hits)[idigi]->GetTime(id);
 	smeartime.push_back(hit_time_smear);
@@ -932,13 +949,17 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 				      primaryParentID,
 				      photonStartTime,
 				      photonStartPos,
-				      photonEndPos);
+				      photonEndPos,
+				      photonStartDir,
+				      photonEndDir);
       smeartime.clear();
       truetime.clear();
       primaryParentID.clear();
       photonStartTime.clear();
       photonStartPos.clear();
       photonEndPos.clear();
+      photonStartDir.clear();
+      photonEndDir.clear();
     }//idigi
   }//if(WCDC_hits)
 #endif //_SAVE_RAW_HITS

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -411,7 +411,8 @@ WCSimRootTrack::WCSimRootTrack(Int_t ipnu,
 //_____________________________________________________________________________
 
 WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID, Int_t mPMTID, Int_t mPMT_PMTID, std::vector<Float_t> truetime,
-        std::vector<Int_t> primParID, std::vector<Float_t> photonStartTime, std::vector<TVector3> photonStartPos, std::vector<TVector3> photonEndPos)
+        std::vector<Int_t> primParID, std::vector<Float_t> photonStartTime, std::vector<TVector3> photonStartPos, std::vector<TVector3> photonEndPos,
+        std::vector<TVector3> photonStartDir, std::vector<TVector3> photonEndDir)
 {
   // Add a new Cherenkov hit to the list of Cherenkov hits
   TClonesArray &cherenkovhittimes = *fCherenkovHitTimes;
@@ -421,12 +422,18 @@ WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID, Int_t mPM
     fCherenkovHitCounter++;
     Float_t startPos[3];
     Float_t endPos[3];
+    Float_t startDir[3];
+    Float_t endDir[3];
     for(int j=0; j<3; j++){
       startPos[j] = photonStartPos[i][j];
       endPos[j] = photonEndPos[i][j];
+      startDir[j] = photonStartDir[i][j];
+      endDir[j] = photonEndDir[i][j];
     }
     WCSimRootCherenkovHitTime *cherenkovhittime = 
-      new(cherenkovhittimes[fNcherenkovhittimes++]) WCSimRootCherenkovHitTime(truetime[i],primParID[i], photonStartTime[i], startPos, endPos);
+      new(cherenkovhittimes[fNcherenkovhittimes++]) WCSimRootCherenkovHitTime(truetime[i],primParID[i],
+                                                                              photonStartTime[i], startPos, endPos,
+                                                                              startDir, endDir);
   }
 
   Int_t WC_Index[2];
@@ -472,7 +479,8 @@ WCSimRootCherenkovHit::WCSimRootCherenkovHit(Int_t tubeID,
 }
 
 WCSimRootCherenkovHitTime::WCSimRootCherenkovHitTime(Float_t truetime, Int_t primParID,
-						     Float_t photonStartTime, Float_t photonStartPos[3], Float_t photonEndPos[3])
+						     Float_t photonStartTime, Float_t photonStartPos[3], Float_t photonEndPos[3],
+						     Float_t photonStartDir[3], Float_t photonEndDir[3])
 {
   // Create a WCSimRootCherenkovHit object and fill it with stuff
     fTruetime        = truetime; 
@@ -481,6 +489,8 @@ WCSimRootCherenkovHitTime::WCSimRootCherenkovHitTime(Float_t truetime, Int_t pri
     for (int i=0;i<3;i++) {
         fPhotonStartPos[i] = photonStartPos[i];
         fPhotonEndPos[i] = photonEndPos[i];
+        fPhotonStartDir[i] = photonStartDir[i];
+        fPhotonEndDir[i] = photonEndDir[i];
     }
 }
 

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -155,8 +155,9 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
       { 
 	WCSimTrackInformation* infoSec = new WCSimTrackInformation(anInfo);
 	if(anInfo->isSaved()){ // Parent is primary, so we want start pos & time of this secondary
-        infoSec->SetPhotonStartTime((*secondaries)[i]->GetGlobalTime());
-        infoSec->SetPhotonStartPos((*secondaries)[i]->GetPosition());
+		infoSec->SetPhotonStartTime((*secondaries)[i]->GetGlobalTime());
+		infoSec->SetPhotonStartPos((*secondaries)[i]->GetPosition());
+		infoSec->SetPhotonStartDir((*secondaries)[i]->GetMomentumDirection());
 	}
 	infoSec->WillBeSaved(false); // ADDED BY MFECHNER, temporary, 30/8/06
 	(*secondaries)[i]->SetUserInformation(infoSec);

--- a/src/WCSimWCAddDarkNoise.cc
+++ b/src/WCSimWCAddDarkNoise.cc
@@ -197,6 +197,8 @@ void WCSimWCAddDarkNoise::AddDarkNoiseBeforeDigi(WCSimWCDigitsCollection* WCHCPM
 	    ahit->SetPhotonStartTime(PMTindex[noise_pmt],current_time);
 	    ahit->SetPhotonStartPos(PMTindex[noise_pmt], pmt_position);
 	    ahit->SetPhotonEndPos(PMTindex[noise_pmt], pmt_position);
+	    ahit->SetPhotonStartDir(PMTindex[noise_pmt], -pmt_orientation);
+	    ahit->SetPhotonEndDir(PMTindex[noise_pmt], -pmt_orientation);
 	    ahit->SetPreSmearTime(PMTindex[noise_pmt],current_time); //presmear==postsmear for dark noise
 	    pe = WCPMT->rn1pe();
 	    ahit->SetPe(PMTindex[noise_pmt],pe);
@@ -221,6 +223,8 @@ void WCSimWCAddDarkNoise::AddDarkNoiseBeforeDigi(WCSimWCDigitsCollection* WCHCPM
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartTime(PMTindex[noise_pmt],current_time);
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartPos(PMTindex[noise_pmt],(*WCHCPMT)[ list[noise_pmt]-1 ]->GetPos());
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonEndPos(PMTindex[noise_pmt],(*WCHCPMT)[ list[noise_pmt]-1 ]->GetPos());
+	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartDir(PMTindex[noise_pmt],-(*WCHCPMT)[ list[noise_pmt]-1 ]->GetOrientation());
+	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonEndDir(PMTindex[noise_pmt],-(*WCHCPMT)[ list[noise_pmt]-1 ]->GetOrientation());
 	  PMTindex[noise_pmt]++;
 #ifdef WCSIMWCADDDARKNOISE_VERBOSE
 	  if(noise_pmt < NPMTS_VERBOSE)

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -138,6 +138,8 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	    float photon_starttime = (*WCHC)[i]->GetPhotonStartTime(ip);
 	    G4ThreeVector photon_startpos = (*WCHC)[i]->GetPhotonStartPos(ip);
 	    G4ThreeVector photon_endpos = (*WCHC)[i]->GetPhotonEndPos(ip);
+	    G4ThreeVector photon_startdir = (*WCHC)[i]->GetPhotonStartDir(ip);
+	    G4ThreeVector photon_enddir = (*WCHC)[i]->GetPhotonEndDir(ip);
 	    
 	    if ( DigiHitMapPMT[tube] == 0) {
 	      WCSimWCDigi* Digi = new WCSimWCDigi();
@@ -154,6 +156,8 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	      Digi->SetPhotonStartTime(ip,photon_starttime);
 	      Digi->SetPhotonStartPos(ip,photon_startpos);
 	      Digi->SetPhotonEndPos(ip,photon_endpos);
+	      Digi->SetPhotonStartDir(ip,photon_startdir);
+	      Digi->SetPhotonEndDir(ip,photon_enddir);
 	      DigiHitMapPMT[tube] = DigitsCollection->insert(Digi);
 	    }	
 	    else {
@@ -170,6 +174,8 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonStartTime(ip,photon_starttime);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonStartPos(ip,photon_startpos);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonEndPos(ip,photon_endpos);
+	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonStartDir(ip,photon_startdir);
+	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonEndDir(ip,photon_enddir);
 	    }
       
 	  } // Loop over hits in each PMT

--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -86,16 +86,19 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
   G4int primParentID = -1;
   G4float photonStartTime;
   G4ThreeVector photonStartPos;
+  G4ThreeVector photonStartDir;
   if (trackinfo) {
     //Skip secondaries and match to mother process, eg. muon, decay particle, gamma from pi0/nCapture.
     primParentID = trackinfo->GetPrimaryParentID();  //!= ParentID.
     photonStartTime = trackinfo->GetPhotonStartTime();
     photonStartPos = trackinfo->GetPhotonStartPos();
+    photonStartDir = trackinfo->GetPhotonStartDir();
   }
   else { // if there is no trackinfo, then it is a primary particle!
     primParentID = aStep->GetTrack()->GetTrackID();
     photonStartTime = aStep->GetTrack()->GetGlobalTime();
     photonStartPos = aStep->GetTrack()->GetVertexPosition();
+    photonStartDir = aStep->GetTrack()->GetVertexMomentumDirection();
   }
 
 
@@ -231,6 +234,8 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartTime(photonStartTime);
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartPos(photonStartPos);
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonEndPos(worldPosition);
+	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartDir(photonStartDir);
+	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonEndDir(worldDirection);
 	   
 	   //     if ( particleDefinition != G4OpticalPhoton::OpticalPhotonDefinition() )
 	   //       newHit->Print();
@@ -242,6 +247,8 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartTime(photonStartTime);
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartPos(photonStartPos);
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonEndPos(worldPosition);
+	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartDir(photonStartDir);
+	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonEndDir(worldDirection);
 	 
        }
      }


### PR DESCRIPTION
Adds tracking of photon start and end directions for true PMT hits, in the same way as we are already tracking photon start and end positions.
Also fixes a possible edge-case bug where photon end position of hits on a single PMT get incorrectly ordered.